### PR TITLE
mgr/openattic: Fix cherrypy shutdown handler

### DIFF
--- a/src/pybind/mgr/openattic/module.py
+++ b/src/pybind/mgr/openattic/module.py
@@ -3,17 +3,21 @@
 """
 openATTIC mgr plugin (based on CherryPy)
 """
-
+import os
 import cherrypy
 from cherrypy import tools
 
 from mgr_module import MgrModule
 
+# cherrypy likes to sys.exit on error.  don't let it take us down too!
+def os_exit_noop():
+    pass
+
+os._exit = os_exit_noop
+
 """
 openATTIC CherryPy Module
 """
-
-
 class Module(MgrModule):
 
     """
@@ -29,11 +33,14 @@ class Module(MgrModule):
                                })
         cherrypy.tree.mount(Module.HelloWorld(self), "/")
         cherrypy.engine.start()
-        cherrypy.engine.wait(state=cherrypy.engine.states.STOPPED)
+        self.log.info("Waiting for engine...")
+        cherrypy.engine.block();
+        self.log.info("Engine done.")
 
     def shutdown(self):
-        cherrypy.engine.wait(state=cherrypy.engine.states.STARTED)
-        cherrypy.engine.stop()
+        self.log.info("Stopping server...")
+        cherrypy.engine.exit()
+        self.log.info("Stopped server")
 
     def handle_command(self, cmd):
         pass


### PR DESCRIPTION
This patch prevents cherrypy from crashing the mgr process when some
exception is thrown when shutting down cherrypy.

Signed-off-by: Ricardo Dias <rdias@suse.com>