### PR TITLE
mgr/dashboard_v2: Refactor tests code and fix pylint

### DIFF
--- a/src/pybind/mgr/dashboard_v2/.gitignore
+++ b/src/pybind/mgr/dashboard_v2/.gitignore
@@ -1,8 +1,8 @@
-.coverage
+.coverage*
 htmlcov
 .tox
 coverage.xml
-junit.xml
+junit*xml
 __pycache__
 
 # IDE

--- a/src/pybind/mgr/dashboard_v2/.pylintrc
+++ b/src/pybind/mgr/dashboard_v2/.pylintrc
@@ -126,7 +126,12 @@ disable=print-statement,
         next-method-defined,
         dict-items-not-iterating,
         dict-keys-not-iterating,
-        dict-values-not-iterating
+        dict-values-not-iterating,
+        missing-docstring,
+        invalid-name,
+        no-self-use,
+        too-few-public-methods,
+        no-member
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/src/pybind/mgr/dashboard_v2/controllers/auth.py
+++ b/src/pybind/mgr/dashboard_v2/controllers/auth.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import bcrypt
-import cherrypy
 import time
 import sys
 
-from ..tools import ApiController, AuthRequired, RESTController
+import bcrypt
+import cherrypy
+
+from ..tools import ApiController, RESTController
 
 
 @ApiController('auth')
@@ -30,6 +31,7 @@ class Auth(RESTController):
     DEFAULT_SESSION_EXPIRE = 1200.0
 
     def __init__(self):
+        # pylint: disable=E1101
         self._mod = Auth._mgr_module_
         self._log = self._mod.log
 
@@ -46,10 +48,10 @@ class Auth(RESTController):
             cherrypy.session[Auth.SESSION_KEY_TS] = now
             self._log.debug("Login successful")
             return {'username': username}
-        else:
-            cherrypy.response.status = 403
-            self._log.debug("Login fail")
-            return {'detail': 'Invalid credentials'}
+
+        cherrypy.response.status = 403
+        self._log.debug("Login fail")
+        return {'detail': 'Invalid credentials'}
 
     def bulk_delete(self):
         self._log.debug("Logout successful")
@@ -62,8 +64,7 @@ class Auth(RESTController):
             salt_password = bcrypt.gensalt()
         if sys.version_info > (3, 0):
             return bcrypt.hashpw(password, salt_password)
-        else:
-            return bcrypt.hashpw(password.encode('utf8'), salt_password)
+        return bcrypt.hashpw(password.encode('utf8'), salt_password)
 
     @staticmethod
     def check_auth():
@@ -76,8 +77,7 @@ class Auth(RESTController):
                                           'that resource')
         now = time.time()
         expires = float(module.get_localized_config(
-                        'session-expire',
-                        Auth.DEFAULT_SESSION_EXPIRE))
+            'session-expire', Auth.DEFAULT_SESSION_EXPIRE))
         if expires > 0:
             username_ts = cherrypy.session.get(Auth.SESSION_KEY_TS, None)
             if username_ts and float(username_ts) < (now - expires):

--- a/src/pybind/mgr/dashboard_v2/controllers/ping.py
+++ b/src/pybind/mgr/dashboard_v2/controllers/ping.py
@@ -10,7 +10,7 @@ from ..tools import ApiController, AuthRequired, RESTController
 @AuthRequired()
 class Ping(object):
     @cherrypy.expose
-    def default(self, *args):
+    def default(self):
         return "pong"
 
 

--- a/src/pybind/mgr/dashboard_v2/requirements.txt
+++ b/src/pybind/mgr/dashboard_v2/requirements.txt
@@ -16,6 +16,8 @@ pbr==3.1.1
 pluggy==0.6.0
 portend==2.2
 py==1.5.2
+pycodestyle==2.3.1
+pycparser==2.18
 pylint==1.8.2
 pytest==3.3.2
 pytest-cov==2.5.1

--- a/src/pybind/mgr/dashboard_v2/tests/helper.py
+++ b/src/pybind/mgr/dashboard_v2/tests/helper.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+# pylint: disable=W0212
 from __future__ import absolute_import
 
 import json

--- a/src/pybind/mgr/dashboard_v2/tests/helper.py
+++ b/src/pybind/mgr/dashboard_v2/tests/helper.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+import json
+
+import cherrypy
+from cherrypy.test import helper
+
+from ..module import Module
+from ..tools import load_controller
+
+
+class ApiControllerTestCase(helper.CPWebCase):
+    @staticmethod
+    def setup_test(controllers, authentication=True):
+        module = Module('dashboard', None, None)
+        ApiControllerTestCase._mgr_module = module
+        for ctrl in controllers:
+            cls = load_controller(module, ctrl)
+            if not authentication:
+                cls._cp_config['tools.autenticate.on'] = False
+            cherrypy.tree.mount(cls(), '/api/{}'.format(cls._cp_path_))
+
+    def _request(self, url, method, data=None):
+        if not data:
+            b = None
+            h = None
+        else:
+            b = json.dumps(data)
+            h = [('Content-Type', 'application/json'),
+                 ('Content-Length', str(len(b)))]
+        self.getPage(url, method=method, body=b, headers=h)
+
+    def _get(self, url):
+        self._request(url, 'GET')
+
+    def _post(self, url, data=None):
+        self._request(url, 'POST', data)
+
+    def _delete(self, url, data=None):
+        self._request(url, 'DELETE', data)
+
+    def _put(self, url, data=None):
+        self._request(url, 'PUT', data)

--- a/src/pybind/mgr/dashboard_v2/tests/test_auth.py
+++ b/src/pybind/mgr/dashboard_v2/tests/test_auth.py
@@ -2,15 +2,14 @@
 
 from __future__ import absolute_import
 
-import json
 import time
 
+import cherrypy
 from cherrypy.lib.sessions import RamSession
-from cherrypy.test import helper
 from mock import patch
 
-from ..module import Module, cherrypy
-from ..tools import load_controller
+from .helper import ApiControllerTestCase
+from ..controllers.auth import Auth
 
 class Ping(object):
     @cherrypy.expose
@@ -19,38 +18,20 @@ class Ping(object):
         pass
 
 
-class AuthTest(helper.CPWebCase):
+class AuthTest(ApiControllerTestCase):
     @staticmethod
     def setup_server():
-        module = Module('dashboard', None, None)
-        AuthTest.Auth = load_controller(module, 'Auth')
+        ApiControllerTestCase.setup_test(['Auth'])
+        module = ApiControllerTestCase._mgr_module
 
         cherrypy.tools.autenticate = cherrypy.Tool('before_handler',
-                                                   AuthTest.Auth.check_auth)
+                                                   Auth.check_auth)
 
-        cherrypy.tree.mount(AuthTest.Auth(), "/api/auth")
         cherrypy.tree.mount(Ping(), "/api/test",
                             config={'/': {'tools.autenticate.on': True}})
         module.set_localized_config('session-expire','2')
         module.set_localized_config('username','admin')
-        pass_hash = AuthTest.Auth.password_hash('admin')
-        module.set_localized_config('password', pass_hash)
-
-    def _request(self, url, method, data=None):
-        if not data:
-            b = None
-            h = None
-        else:
-            b = json.dumps(data)
-            h = [('Content-Type', 'application/json'),
-                 ('Content-Length', str(len(b)))]
-        self.getPage(url, method=method, body=b, headers=h)
-
-    def _post(self, url, data=None):
-        self._request(url, 'POST', data)
-
-    def _delete(self, url, data=None):
-        self._request(url, 'DELETE', data)
+        module.set_localized_config('password', Auth.password_hash('admin'))
 
     def test_login_valid(self):
         sess_mock = RamSession()
@@ -58,8 +39,7 @@ class AuthTest(helper.CPWebCase):
             self._post("/api/auth", {'username': 'admin', 'password': 'admin'})
             self.assertStatus('201 Created')
             self.assertBody('{"username": "admin"}')
-            self.assertEquals(sess_mock.get(AuthTest.Auth.SESSION_KEY),
-                              'admin')
+            self.assertEquals(sess_mock.get(Auth.SESSION_KEY), 'admin')
 
     def test_login_invalid(self):
         sess_mock = RamSession()
@@ -67,38 +47,35 @@ class AuthTest(helper.CPWebCase):
             self._post("/api/auth", {'username': 'admin', 'password': 'inval'})
             self.assertStatus('403 Forbidden')
             self.assertBody('{"detail": "Invalid credentials"}')
-            self.assertEquals(sess_mock.get(AuthTest.Auth.SESSION_KEY), None)
+            self.assertEquals(sess_mock.get(Auth.SESSION_KEY), None)
 
     def test_logout(self):
         sess_mock = RamSession()
         with patch('cherrypy.session', sess_mock, create=True):
             self._post("/api/auth", {'username': 'admin', 'password': 'admin'})
-            self.assertEquals(sess_mock.get(AuthTest.Auth.SESSION_KEY),
-                              'admin')
+            self.assertEquals(sess_mock.get(Auth.SESSION_KEY), 'admin')
             self._delete("/api/auth")
             self.assertStatus('204 No Content')
             self.assertBody('')
-            self.assertEquals(sess_mock.get(AuthTest.Auth.SESSION_KEY), None)
+            self.assertEquals(sess_mock.get(Auth.SESSION_KEY), None)
 
     def test_session_expire(self):
         sess_mock = RamSession()
         with patch('cherrypy.session', sess_mock, create=True):
             self._post("/api/auth", {'username': 'admin', 'password': 'admin'})
             self.assertStatus('201 Created')
-            self.assertEquals(sess_mock.get(AuthTest.Auth.SESSION_KEY),
-                              'admin')
+            self.assertEquals(sess_mock.get(Auth.SESSION_KEY), 'admin')
             self._post("/api/test/ping")
             self.assertStatus('200 OK')
-            self.assertEquals(sess_mock.get(AuthTest.Auth.SESSION_KEY),
-                              'admin')
+            self.assertEquals(sess_mock.get(Auth.SESSION_KEY), 'admin')
             time.sleep(3)
             self._post("/api/test/ping")
             self.assertStatus('401 Unauthorized')
-            self.assertEquals(sess_mock.get(AuthTest.Auth.SESSION_KEY), None)
+            self.assertEquals(sess_mock.get(Auth.SESSION_KEY), None)
 
     def test_unauthorized(self):
         sess_mock = RamSession()
         with patch('cherrypy.session', sess_mock, create=True):
             self._post("/api/test/ping")
             self.assertStatus('401 Unauthorized')
-            self.assertEquals(sess_mock.get(AuthTest.Auth.SESSION_KEY), None)
+            self.assertEquals(sess_mock.get(Auth.SESSION_KEY), None)

--- a/src/pybind/mgr/dashboard_v2/tests/test_auth.py
+++ b/src/pybind/mgr/dashboard_v2/tests/test_auth.py
@@ -29,8 +29,8 @@ class AuthTest(ApiControllerTestCase):
 
         cherrypy.tree.mount(Ping(), "/api/test",
                             config={'/': {'tools.autenticate.on': True}})
-        module.set_localized_config('session-expire','2')
-        module.set_localized_config('username','admin')
+        module.set_localized_config('session-expire', '2')
+        module.set_localized_config('username', 'admin')
         module.set_localized_config('password', Auth.password_hash('admin'))
 
     def test_login_valid(self):
@@ -39,7 +39,7 @@ class AuthTest(ApiControllerTestCase):
             self._post("/api/auth", {'username': 'admin', 'password': 'admin'})
             self.assertStatus('201 Created')
             self.assertBody('{"username": "admin"}')
-            self.assertEquals(sess_mock.get(Auth.SESSION_KEY), 'admin')
+            self.assertEqual(sess_mock.get(Auth.SESSION_KEY), 'admin')
 
     def test_login_invalid(self):
         sess_mock = RamSession()
@@ -47,35 +47,35 @@ class AuthTest(ApiControllerTestCase):
             self._post("/api/auth", {'username': 'admin', 'password': 'inval'})
             self.assertStatus('403 Forbidden')
             self.assertBody('{"detail": "Invalid credentials"}')
-            self.assertEquals(sess_mock.get(Auth.SESSION_KEY), None)
+            self.assertEqual(sess_mock.get(Auth.SESSION_KEY), None)
 
     def test_logout(self):
         sess_mock = RamSession()
         with patch('cherrypy.session', sess_mock, create=True):
             self._post("/api/auth", {'username': 'admin', 'password': 'admin'})
-            self.assertEquals(sess_mock.get(Auth.SESSION_KEY), 'admin')
+            self.assertEqual(sess_mock.get(Auth.SESSION_KEY), 'admin')
             self._delete("/api/auth")
             self.assertStatus('204 No Content')
             self.assertBody('')
-            self.assertEquals(sess_mock.get(Auth.SESSION_KEY), None)
+            self.assertEqual(sess_mock.get(Auth.SESSION_KEY), None)
 
     def test_session_expire(self):
         sess_mock = RamSession()
         with patch('cherrypy.session', sess_mock, create=True):
             self._post("/api/auth", {'username': 'admin', 'password': 'admin'})
             self.assertStatus('201 Created')
-            self.assertEquals(sess_mock.get(Auth.SESSION_KEY), 'admin')
+            self.assertEqual(sess_mock.get(Auth.SESSION_KEY), 'admin')
             self._post("/api/test/ping")
             self.assertStatus('200 OK')
-            self.assertEquals(sess_mock.get(Auth.SESSION_KEY), 'admin')
+            self.assertEqual(sess_mock.get(Auth.SESSION_KEY), 'admin')
             time.sleep(3)
             self._post("/api/test/ping")
             self.assertStatus('401 Unauthorized')
-            self.assertEquals(sess_mock.get(Auth.SESSION_KEY), None)
+            self.assertEqual(sess_mock.get(Auth.SESSION_KEY), None)
 
     def test_unauthorized(self):
         sess_mock = RamSession()
         with patch('cherrypy.session', sess_mock, create=True):
             self._post("/api/test/ping")
             self.assertStatus('401 Unauthorized')
-            self.assertEquals(sess_mock.get(Auth.SESSION_KEY), None)
+            self.assertEqual(sess_mock.get(Auth.SESSION_KEY), None)

--- a/src/pybind/mgr/dashboard_v2/tests/test_ping.py
+++ b/src/pybind/mgr/dashboard_v2/tests/test_ping.py
@@ -2,44 +2,17 @@
 
 from __future__ import absolute_import
 
-import json
+from .helper import ApiControllerTestCase
 
-from cherrypy.test import helper
-
-from ..controllers.auth import Auth
-from ..module import Module, cherrypy
-from ..tools import load_controller
-
-class SimpleCPTest(helper.CPWebCase):
+class SimpleCPTest(ApiControllerTestCase):
     @staticmethod
     def setup_server():
-
-        cherrypy.tools.autenticate = cherrypy.Tool('before_handler',
-                                                   Auth.check_auth)
-        module = Module('attic', None, None)
-        Ping = load_controller(module, 'Ping')
-        Echo = load_controller(module, 'Echo')
-        EchoArgs = load_controller(module, 'EchoArgs')
-        cherrypy.tree.mount(Ping(), "/api/ping")
-        cherrypy.tree.mount(Echo(), "/api/echo2")
-        cherrypy.tree.mount(EchoArgs(), "/api/echo1")
-
-    def _request(self, url, method, data=None):
-        if not data:
-            b = None
-            h = None
-        else:
-            b = json.dumps(data)
-            h = [('Content-Type', 'application/json'),
-                 ('Content-Length', str(len(b)))]
-        self.getPage(url, method=method, body=b, headers=h)
-
-    def _post(self, url, data=None):
-        self._request(url, 'POST', data)
+        ApiControllerTestCase.setup_test(['Ping', 'Echo', 'EchoArgs'],
+                                         authentication=False)
 
     def test_ping(self):
         self.getPage("/api/ping")
-        self.assertStatus('401 Unauthorized')
+        self.assertStatus('200 OK')
 
     def test_echo(self):
         self._post("/api/echo2", {'msg': 'Hello World'})

--- a/src/pybind/mgr/dashboard_v2/tests/test_ping.py
+++ b/src/pybind/mgr/dashboard_v2/tests/test_ping.py
@@ -21,4 +21,3 @@ class SimpleCPTest(ApiControllerTestCase):
     def test_echo_args(self):
         self._post("/api/echo1", {'msg': 'Hello World'})
         self.assertStatus('201 Created')
-

--- a/src/pybind/mgr/dashboard_v2/tests/test_tools.py
+++ b/src/pybind/mgr/dashboard_v2/tests/test_tools.py
@@ -10,7 +10,7 @@ from mock import patch
 from .helper import ApiControllerTestCase
 from ..tools import RESTController
 
-
+# pylint: disable=W0613
 class FooResource(RESTController):
     elems = []
 
@@ -30,7 +30,7 @@ class FooResource(RESTController):
     def bulk_delete(self):
         FooResource.elems = []
 
-
+# pylint: disable=C0102
 class Root(object):
     foo = FooResource()
 

--- a/src/pybind/mgr/dashboard_v2/tests/test_tools.py
+++ b/src/pybind/mgr/dashboard_v2/tests/test_tools.py
@@ -1,0 +1,66 @@
+from __future__ import absolute_import
+
+import json
+
+import cherrypy
+from cherrypy.lib.sessions import RamSession
+from cherrypy.test import helper
+from mock import patch
+
+from ..tools import RESTController
+
+
+class FooResource(RESTController):
+    elems = []
+
+    def list(self, *vpath, **params):
+        return FooResource.elems
+
+    def create(self, data, *args, **kwargs):
+        FooResource.elems.append(data)
+        return data
+
+    def get(self, key, *args, **kwargs):
+        return FooResource.elems[int(key)]
+
+    def delete(self, key):
+        del FooResource.elems[int(key)]
+
+    def bulk_delete(self):
+        FooResource.elems = []
+
+
+class Root(object):
+    foo = FooResource()
+
+class RESTControllerTest(helper.CPWebCase):
+    @staticmethod
+    def setup_server():
+        cherrypy.tree.mount(Root())
+
+    def test_empty(self):
+        self.getPage("/foo", method='DELETE')
+        self.assertStatus(204)
+        self.getPage("/foo")
+        self.assertStatus('200 OK')
+        self.assertHeader('Content-Type', 'application/json')
+        self.assertBody('[]')
+
+    def test_fill(self):
+        sess_mock = RamSession()
+        with patch('cherrypy.session', sess_mock, create=True):
+            body = json.dumps({'a': 'b'})
+            for _ in range(5):
+
+                self.getPage("/foo", method='POST', body=body, headers=[
+                    ('Content-Type', 'application/json'),
+                    ('Content-Length', str(len(body)))
+                ])
+                self.assertBody(body)
+                self.assertStatus(201)
+                self.assertHeader('Content-Type', 'application/json')
+
+            self.getPage("/foo")
+            self.assertStatus('200 OK')
+            self.assertHeader('Content-Type', 'application/json')
+            self.assertBody(json.dumps([{'a': 'b'}] * 5))

--- a/src/pybind/mgr/dashboard_v2/tests/test_tools.py
+++ b/src/pybind/mgr/dashboard_v2/tests/test_tools.py
@@ -1,12 +1,13 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
 import json
 
 import cherrypy
 from cherrypy.lib.sessions import RamSession
-from cherrypy.test import helper
 from mock import patch
 
+from .helper import ApiControllerTestCase
 from ..tools import RESTController
 
 
@@ -33,15 +34,16 @@ class FooResource(RESTController):
 class Root(object):
     foo = FooResource()
 
-class RESTControllerTest(helper.CPWebCase):
+class RESTControllerTest(ApiControllerTestCase):
     @staticmethod
     def setup_server():
+        ApiControllerTestCase.setup_test([])
         cherrypy.tree.mount(Root())
 
     def test_empty(self):
-        self.getPage("/foo", method='DELETE')
+        self._delete("/foo")
         self.assertStatus(204)
-        self.getPage("/foo")
+        self._get("/foo")
         self.assertStatus('200 OK')
         self.assertHeader('Content-Type', 'application/json')
         self.assertBody('[]')
@@ -51,16 +53,12 @@ class RESTControllerTest(helper.CPWebCase):
         with patch('cherrypy.session', sess_mock, create=True):
             body = json.dumps({'a': 'b'})
             for _ in range(5):
-
-                self.getPage("/foo", method='POST', body=body, headers=[
-                    ('Content-Type', 'application/json'),
-                    ('Content-Length', str(len(body)))
-                ])
+                self._post("/foo", {'a': 'b'})
                 self.assertBody(body)
                 self.assertStatus(201)
                 self.assertHeader('Content-Type', 'application/json')
 
-            self.getPage("/foo")
+            self._get("/foo")
             self.assertStatus('200 OK')
             self.assertHeader('Content-Type', 'application/json')
             self.assertBody(json.dumps([{'a': 'b'}] * 5))

--- a/src/pybind/mgr/dashboard_v2/tox.ini
+++ b/src/pybind/mgr/dashboard_v2/tox.ini
@@ -1,26 +1,34 @@
 [tox]
-envlist = py27,py3,lint
+envlist = cov-init,py27,py3,cov-report,lint
 skipsdist = true
 
-[testenv:py27]
+[testenv]
 deps=-r{toxinidir}/requirements.txt
 setenv=
     UNITTEST=true
     WEBTEST_INTERACTIVE=false
+    COVERAGE_FILE= .coverage.{envname}
 commands=
-    {envbindir}/py.test --cov=. --cov-report=term tests/
+    {envbindir}/py.test --cov=. --cov-report= --junitxml=junit.{envname}.xml tests/
 
-[testenv:py3]
-deps=-r{toxinidir}/requirements.txt
-setenv=
-    UNITTEST=true
-    WEBTEST_INTERACTIVE=false
-commands=
-    {envbindir}/py.test --cov=. --cov-report=term --cov-report=xml --junitxml=junit.xml tests/
+[testenv:cov-init]
+setenv =
+    COVERAGE_FILE = .coverage
+deps = coverage
+commands =
+    coverage erase
+
+[testenv:cov-report]
+setenv =
+    COVERAGE_FILE = .coverage
+deps = coverage
+commands =
+    coverage combine
+    coverage report
+    coverage xml
 
 [testenv:lint]
 deps=-r{toxinidir}/requirements.txt
 commands=
     pylint --rcfile=.pylintrc --jobs=5 . module.py tools.py controllers tests
     pycodestyle --exclude=ceph_module_mock.py,python2.7,tests,.tox,venv .
-

--- a/src/pybind/mgr/dashboard_v2/tox.ini
+++ b/src/pybind/mgr/dashboard_v2/tox.ini
@@ -19,10 +19,8 @@ commands=
     {envbindir}/py.test --cov=. --cov-report=term --cov-report=xml --junitxml=junit.xml tests/
 
 [testenv:lint]
-deps=
-    pylint
-    pycodestyle
+deps=-r{toxinidir}/requirements.txt
 commands=
-    pylint --rcfile=.pylintrc --jobs=5 .
+    pylint --rcfile=.pylintrc --jobs=5 . module.py tools.py controllers tests
     pycodestyle --exclude=ceph_module_mock.py,python2.7,tests,.tox,venv .
 


### PR DESCRIPTION
This PR refactors the unit tests code by creating a helper class that already knows how to load controllers and provides helper methods to make requests.

This PR also fixes the pylint execution and fixes the several errors and warnings

Signed-off-by: Ricardo Dias <rdias@suse.com>