### PR TITLE
mgr/dashboard_v2: Disable CherryPi autoreload feature

### DIFF
--- a/src/pybind/mgr/dashboard_v2/module.py
+++ b/src/pybind/mgr/dashboard_v2/module.py
@@ -54,6 +54,7 @@ class Module(MgrModule):
             cherrypy.config.update({
                 'server.socket_host': server_addr,
                 'server.socket_port': int(server_port),
+                'engine.autoreload.on': False
             })
         cherrypy.tools.autenticate = cherrypy.Tool('before_handler',
                                                    Auth.check_auth)


### PR DESCRIPTION
It does not work, either with the below code which will fix the error

2018-01-26 13:21:15.779 7fa454add700 -1 log_channel(cluster) log [ERR] : Unhandled exception from module 'dashboard_v2' while running on mgr.x: execv() arg 2 must not be empty
2018-01-26 13:21:15.779 7fa454add700 -1 dashboard_v2.serve: File "/ceph/src/pybind/mgr/dashboard_v2/module.py", line 112, in serve

```
# Get the CherryPy autoreload feature working.
def _get_true_argv():
    return sys.argv[:]
cherrypy.engine._get_true_argv = _get_true_argv
```

Signed-off-by: Volker Theile <vtheile@suse.com>