### PR TITLE
mgr/dashboard_v2: fix pycodestyle to exclude the frontend files

### DIFF
--- a/src/pybind/mgr/dashboard_v2/tox.ini
+++ b/src/pybind/mgr/dashboard_v2/tox.ini
@@ -31,4 +31,4 @@ commands =
 deps=-r{toxinidir}/requirements.txt
 commands=
     pylint --rcfile=.pylintrc --jobs=5 . module.py tools.py ceph_module_mock.py controllers tests
-    pycodestyle --exclude=python2.7,.tox,venv .
+    pycodestyle --exclude=python2.7,.tox,venv,frontend .


### PR DESCRIPTION
Signed-off-by: Ricardo Dias <rdias@suse.com>