### PR TITLE
 mgr/dashboard_v2: Refactoring of the access to mgr module instance, and README update

### DIFF
--- a/src/pybind/mgr/dashboard_v2/README.rst
+++ b/src/pybind/mgr/dashboard_v2/README.rst
@@ -152,3 +152,55 @@ Example::
 
 Now only authenticated users will be able to "ping" your controller.
 
+
+How to access the manager module instance from a controller?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Each controller class annoted with the ``ApiController`` decorator is injected
+with a class property that points to the manager module global instance. The
+property is named ``mgr``.
+
+Example::
+
+  import cherrypy
+  from ..tools import ApiController, RESTController
+
+  @ApiController('servers')
+  class Servers(RESTController):
+    def list(self):
+      self.logger.debug('Listing available servers')
+      return {'servers': self.mgr.list_servers()}
+
+We also inject a class property ``logger`` that is provided by the module class
+to easily add log messages.
+
+
+How to write a unit test for a controller?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+We provide a test helper class called ``ControllerTestCase`` to easily create
+unit tests for your controller.
+
+If we want to write a unit test for the above ``Ping2`` controller, create a
+``test_ping2.py`` file under the ``tests`` directory with the following code::
+
+  from .helper import ControllerTestCase
+  from .controllers.ping2 import Ping2
+
+  class Ping2Test(ControllerTestCase):
+      @classmethod
+      def setup_test(cls):
+          Ping2._cp_config['tools.authentica.on'] = False
+
+      def test_ping2(self):
+          self._get("/api/ping2")
+          self.assertStatus(200)
+          self.assertJsonBody({'msg': 'Hello'})
+
+The ``ControllerTestCase`` class will call the dashboard module code that loads
+the controllers and initializes the CherryPy webserver. Then it will call the
+``setup_test()`` class method to execute additional instructions that each test
+case needs to add to the test.
+In the example above we use the ``setup_test()`` method to disable the
+authentication handler for the ``Ping2`` controller.
+

--- a/src/pybind/mgr/dashboard_v2/controllers/auth.py
+++ b/src/pybind/mgr/dashboard_v2/controllers/auth.py
@@ -30,31 +30,26 @@ class Auth(RESTController):
 
     DEFAULT_SESSION_EXPIRE = 1200.0
 
-    def __init__(self):
-        # pylint: disable=E1101
-        self._mod = Auth._mgr_module_
-        self._log = self._mod.log
-
     @RESTController.args_from_json
     def create(self, username, password):
         now = time.time()
-        config_username = self._mod.get_localized_config('username', None)
-        config_password = self._mod.get_localized_config('password', None)
+        config_username = self.mgr.get_localized_config('username', None)
+        config_password = self.mgr.get_localized_config('password', None)
         hash_password = Auth.password_hash(password,
                                            config_password)
         if username == config_username and hash_password == config_password:
             cherrypy.session.regenerate()
             cherrypy.session[Auth.SESSION_KEY] = username
             cherrypy.session[Auth.SESSION_KEY_TS] = now
-            self._log.debug('Login successful')
+            self.logger.debug('Login successful')
             return {'username': username}
 
         cherrypy.response.status = 403
-        self._log.debug('Login failed')
+        self.logger.debug('Login failed')
         return {'detail': 'Invalid credentials'}
 
     def bulk_delete(self):
-        self._log.debug('Logout successful')
+        self.logger.debug('Logout successful')
         cherrypy.session[Auth.SESSION_KEY] = None
         cherrypy.session[Auth.SESSION_KEY_TS] = None
 
@@ -68,22 +63,21 @@ class Auth(RESTController):
 
     @staticmethod
     def check_auth():
-        module = Auth._mgr_module_
         username = cherrypy.session.get(Auth.SESSION_KEY)
         if not username:
-            module.log.debug('Unauthorized access to {}'.format(cherrypy.url(
+            Auth.logger.debug('Unauthorized access to {}'.format(cherrypy.url(
                 relative='server')))
             raise cherrypy.HTTPError(401, 'You are not authorized to access '
                                           'that resource')
         now = time.time()
-        expires = float(module.get_localized_config(
+        expires = float(Auth.mgr.get_localized_config(
             'session-expire', Auth.DEFAULT_SESSION_EXPIRE))
         if expires > 0:
             username_ts = cherrypy.session.get(Auth.SESSION_KEY_TS, None)
             if username_ts and float(username_ts) < (now - expires):
                 cherrypy.session[Auth.SESSION_KEY] = None
                 cherrypy.session[Auth.SESSION_KEY_TS] = None
-                module.log.debug('Session expired')
+                Auth.logger.debug('Session expired')
                 raise cherrypy.HTTPError(401,
                                          'Session expired. You are not '
                                          'authorized to access that resource')
@@ -91,6 +85,6 @@ class Auth(RESTController):
 
     @staticmethod
     def set_login_credentials(username, password):
-        Auth._mgr_module_.set_localized_config('username', username)
+        Auth.mgr.set_localized_config('username', username)
         hashed_passwd = Auth.password_hash(password)
-        Auth._mgr_module_.set_localized_config('password', hashed_passwd)
+        Auth.mgr.set_localized_config('password', hashed_passwd)

--- a/src/pybind/mgr/dashboard_v2/controllers/cluster.py
+++ b/src/pybind/mgr/dashboard_v2/controllers/cluster.py
@@ -16,10 +16,6 @@ cluster_serializer = partial(nodb_serializer, CephCluster)
 @ApiController('cluster')
 class Cluster(RESTController):
 
-    def __init__(self):
-        self._mod = Cluster._mgr_module_
-        self._log = self._mod.log
-
     def list(self):
         with nodb_context(self):
             map(cluster_serializer, CephCluster.objects.all())

--- a/src/pybind/mgr/dashboard_v2/models/cluster.py
+++ b/src/pybind/mgr/dashboard_v2/models/cluster.py
@@ -44,7 +44,7 @@ class CephCluster(NodbModel, SendCommandApiMixin):
     @staticmethod
     def get_all_objects(api_controller, query):
         """:type api_controller: RESTController"""
-        fsid = api_controller._mgr_module_.get("mon_status")['json'].data['monmap']['fsid']
+        fsid = api_controller.mgr.get("mon_status")['json'].data['monmap']['fsid']
         return [CephCluster(fsid)]
 
     def save(self, update_fields=None, force_update=False, *args, **kwargs):

--- a/src/pybind/mgr/dashboard_v2/models/send_command_api.py
+++ b/src/pybind/mgr/dashboard_v2/models/send_command_api.py
@@ -13,7 +13,7 @@ class SendCommandApiMixin(object):
 
     @cached_property
     def send_command_api(self):
-        mgr = NodbManager.nodb_context._mgr_module_  # type: MgrModule
+        mgr = NodbManager.nodb_context.mgr  # type: MgrModule
 
         return SendCommandApi(mgr)
 

--- a/src/pybind/mgr/dashboard_v2/tools.py
+++ b/src/pybind/mgr/dashboard_v2/tools.py
@@ -58,7 +58,8 @@ def load_controllers(mgrmodule):
         for _, cls in mod.__dict__.items():
             if isinstance(cls, type) and hasattr(cls, '_cp_controller_'):
                 # found controller
-                cls._mgr_module_ = mgrmodule
+                cls.mgr = mgrmodule
+                cls.logger = mgrmodule.log
                 controllers.append(cls)
 
     return controllers
@@ -201,9 +202,11 @@ class ExternalCommandError(Exception):
         elif cmd is None:
             s = 'error={} code={}'.format(err, code_string)
         else:
-            cmd = cmd['prefix'] if isinstance(cmd, dict) and 'prefix' in cmd else cmd
+            cmd = cmd['prefix'] if isinstance(cmd, dict) and 'prefix' in cmd \
+                                else cmd
             s = 'Executing "{} {}" failed: "{}" code={}'.format(cmd, ' '.join(
-                ['{}={}'.format(k, v) for k, v in argdict.items()]), err, code_string)
+                ['{}={}'.format(k, v) for k, v in argdict.items()]), err,
+                code_string)
         super(ExternalCommandError, self).__init__(s)
 
 


### PR DESCRIPTION
This PR changes the way controllers have access to the manager module instance. Now to access the manager instance within the controller just use the `mgr()` class method.

The README was also updated with this information, plus a section on how to write unit tests for controllers.

Signed-off-by: Ricardo Dias <rdias@suse.com>