### PR TITLE
Various improvements

### DIFF
--- a/src/pybind/mgr/dashboard_v2/.gitignore
+++ b/src/pybind/mgr/dashboard_v2/.gitignore
@@ -9,6 +9,7 @@ __pycache__
 # IDE
 .vscode
 .idea
+*.egg
 
 # virtualenv
 venv

--- a/src/pybind/mgr/dashboard_v2/README.rst
+++ b/src/pybind/mgr/dashboard_v2/README.rst
@@ -168,8 +168,8 @@ Example::
   @ApiController('servers')
   class Servers(RESTController):
     def list(self):
-      self.logger.debug('Listing available servers')
-      return {'servers': self.mgr.list_servers()}
+      self.log.debug('Listing available servers')
+      return {'servers': self.mgr_module.list_servers()}
 
 We also inject a class property ``logger`` that is provided by the module class
 to easily add log messages.

--- a/src/pybind/mgr/dashboard_v2/controllers/auth.py
+++ b/src/pybind/mgr/dashboard_v2/controllers/auth.py
@@ -33,23 +33,23 @@ class Auth(RESTController):
     @RESTController.args_from_json
     def create(self, username, password):
         now = time.time()
-        config_username = self.mgr.get_localized_config('username', None)
-        config_password = self.mgr.get_localized_config('password', None)
+        config_username = self.mgr_module.get_localized_config('username', None)
+        config_password = self.mgr_module.get_localized_config('password', None)
         hash_password = Auth.password_hash(password,
                                            config_password)
         if username == config_username and hash_password == config_password:
             cherrypy.session.regenerate()
             cherrypy.session[Auth.SESSION_KEY] = username
             cherrypy.session[Auth.SESSION_KEY_TS] = now
-            self.logger.debug('Login successful')
+            self.log.debug('Login successful')
             return {'username': username}
 
         cherrypy.response.status = 403
-        self.logger.debug('Login failed')
+        self.log.debug('Login failed')
         return {'detail': 'Invalid credentials'}
 
     def bulk_delete(self):
-        self.logger.debug('Logout successful')
+        self.log.debug('Logout successful')
         cherrypy.session[Auth.SESSION_KEY] = None
         cherrypy.session[Auth.SESSION_KEY_TS] = None
 
@@ -65,19 +65,19 @@ class Auth(RESTController):
     def check_auth():
         username = cherrypy.session.get(Auth.SESSION_KEY)
         if not username:
-            Auth.logger.debug('Unauthorized access to {}'.format(cherrypy.url(
+            Auth.log.debug('Unauthorized access to {}'.format(cherrypy.url(
                 relative='server')))
             raise cherrypy.HTTPError(401, 'You are not authorized to access '
                                           'that resource')
         now = time.time()
-        expires = float(Auth.mgr.get_localized_config(
+        expires = float(Auth.mgr_module.get_localized_config(
             'session-expire', Auth.DEFAULT_SESSION_EXPIRE))
         if expires > 0:
             username_ts = cherrypy.session.get(Auth.SESSION_KEY_TS, None)
             if username_ts and float(username_ts) < (now - expires):
                 cherrypy.session[Auth.SESSION_KEY] = None
                 cherrypy.session[Auth.SESSION_KEY_TS] = None
-                Auth.logger.debug('Session expired')
+                Auth.log.debug('Session expired')
                 raise cherrypy.HTTPError(401,
                                          'Session expired. You are not '
                                          'authorized to access that resource')
@@ -85,6 +85,6 @@ class Auth(RESTController):
 
     @staticmethod
     def set_login_credentials(username, password):
-        Auth.mgr.set_localized_config('username', username)
+        Auth.mgr_module.set_localized_config('username', username)
         hashed_passwd = Auth.password_hash(password)
-        Auth.mgr.set_localized_config('password', hashed_passwd)
+        Auth.mgr_module.set_localized_config('password', hashed_passwd)

--- a/src/pybind/mgr/dashboard_v2/models/cluster.py
+++ b/src/pybind/mgr/dashboard_v2/models/cluster.py
@@ -44,7 +44,7 @@ class CephCluster(NodbModel, SendCommandApiMixin):
     @staticmethod
     def get_all_objects(api_controller, query):
         """:type api_controller: RESTController"""
-        fsid = api_controller.mgr.get("mon_status")['json'].data['monmap']['fsid']
+        fsid = api_controller.mgr_module.get("mon_status")['json'].data['monmap']['fsid']
         return [CephCluster(fsid)]
 
     def save(self, update_fields=None, force_update=False, *args, **kwargs):

--- a/src/pybind/mgr/dashboard_v2/models/send_command_api.py
+++ b/src/pybind/mgr/dashboard_v2/models/send_command_api.py
@@ -660,10 +660,10 @@ class SendCommandApi(object):
         result = CommandResult('dashboard_v2')
 
         # logger.debug('mod command {}, {}, {}'.format(cmd, argdict, err))
-        self.mgr.send_command(result, 'mon', '', json.dumps(dict(cmd,
-                              format=output_format,
-                              **argdict if argdict is not None else {})), tag='dashboard_v2',
-                              taget=target)
+        self.mgr_module.send_command(result, 'mon', '', json.dumps(dict(cmd,
+                                     format=output_format,
+                                     **argdict if argdict is not None else {})),
+                                     tag='dashboard_v2', taget=target)
 
         ret, out, err = result.wait()
 

--- a/src/pybind/mgr/dashboard_v2/module.py
+++ b/src/pybind/mgr/dashboard_v2/module.py
@@ -74,7 +74,6 @@ class Module(MgrModule):
 
     def serve(self):
         self.configure_cherrypy()
-
         cherrypy.engine.start()
         self.log.info('Waiting for engine...')
         cherrypy.engine.block()
@@ -94,14 +93,14 @@ class Module(MgrModule):
                 .format(cmd['prefix']))
 
     class ApiRoot(object):
-        def __init__(self, mgrmod):
-            ctrls = load_controllers(mgrmod)
-            mgrmod.log.debug('Loaded controllers: {}'.format(ctrls))
+        def __init__(self, mgr_module):
+            ctrls = load_controllers(mgr_module)
+            mgr_module.log.debug('Loaded controllers: {}'.format(ctrls))
             for ctrl in ctrls:
-                mgrmod.log.info('Adding controller: {} -> /api/{}'
-                                .format(ctrl.__name__, ctrl._cp_path_))
-                ins = ctrl()
-                setattr(Module.ApiRoot, ctrl._cp_path_, ins)
+                mgr_module.log.info('Adding controller: {} -> /api/{}'
+                                    .format(ctrl.__name__, ctrl._cp_path_))
+                ctrl_inst = ctrl()
+                setattr(Module.ApiRoot, ctrl._cp_path_, ctrl_inst)
 
     class StaticRoot(object):
         pass

--- a/src/pybind/mgr/dashboard_v2/tools.py
+++ b/src/pybind/mgr/dashboard_v2/tools.py
@@ -42,7 +42,7 @@ def AuthRequired(enabled=True):
     return decorate
 
 
-def load_controllers(mgrmodule):
+def load_controllers(mgr_module):
     # setting sys.path properly when not running under the mgr
     dashboard_dir = os.path.dirname(os.path.realpath(__file__))
     mgr_dir = os.path.dirname(dashboard_dir)
@@ -58,8 +58,8 @@ def load_controllers(mgrmodule):
         for _, cls in mod.__dict__.items():
             if isinstance(cls, type) and hasattr(cls, '_cp_controller_'):
                 # found controller
-                cls.mgr = mgrmodule
-                cls.logger = mgrmodule.log
+                cls.mgr_module = mgr_module
+                cls.log = mgr_module.log
                 controllers.append(cls)
 
     return controllers


### PR DESCRIPTION
* Ignore PyCharm debug egg.
* Rename the variable mgr -> mgr_module in the controller classes. The name 'mgr' implies that this is the Ceph manager instead only the dashboard module.
* Rename the variable logger -> log because this method name is used in the MgrModule, thus it makes no sense to introduce another name.

Signed-off-by: Volker Theile <vtheile@suse.com>