### PR TITLE
mgr/dashboard_v2: Configuration settings support

### DIFF
--- a/src/pybind/mgr/dashboard_v2/README.rst
+++ b/src/pybind/mgr/dashboard_v2/README.rst
@@ -201,3 +201,46 @@ case needs to add to the test.
 In the example above we use the ``setup_test()`` method to disable the
 authentication handler for the ``Ping2`` controller.
 
+
+How to add a new configuration setting?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you need to store some configuration setting for a new feature, we already
+provide an easy mechanism for you to specify/use the new config setting.
+
+For instance, if you want to add a new configuration setting to hold the
+email address of the dashboard admin, just add a setting name as a class
+attribute to the ``Options`` class in the ``settings.py`` file::
+
+  # ...
+  class Options(object):
+    # ...
+
+    ADMIN_EMAIL_ADDRESS = ('admin@admin.com', str)
+
+The value of the class attribute is pair composed by the default value for that
+setting, and the python type of the value.
+
+By declaring the ``ADMIN_EMAIL_ADDRESS`` class attribute, when you restart the
+dashboard plugin, you will atomatically gain two additional CLI commands to
+get and set that setting::
+
+  $ ceph dashboard get-admin-email-address
+  $ ceph dashboard set-admin-email-address <value>
+
+To access, or modify the config setting value from your python code, either
+inside a controller or anywhere else, you just need to import the ``Settings``
+class and access it like this::
+
+  from settings import Settings
+
+  # ...
+  tmp_var = Settings.ADMIN_EMAIL_ADDRESS
+
+  # ....
+  Settings.ADMIN_EMAIL_ADDRESS = 'myemail@admin.com'
+
+The settings management implementation will make sure that if you change a
+setting value from the python code you will see that change when accessing
+that setting from the CLI and vice-versa.
+

--- a/src/pybind/mgr/dashboard_v2/settings.py
+++ b/src/pybind/mgr/dashboard_v2/settings.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+import errno
+import inspect
+from six import with_metaclass
+
+
+class Options(object):
+    """
+    If you need to store some configuration value please add the config option
+    name as a class attribute to this class.
+    """
+    # Grafana settings
+    GRAFANA_API_HOST = ('localhost', str)
+    GRAFANA_API_PORT = (3000, int)
+    GRAFANA_API_USERNAME = ('admin', str)
+    GRAFANA_API_PASSWORD = ('admin', str)
+    GRAFANA_API_SCHEME = ('http', str)
+
+    # RGW settings
+    RGW_API_HOST = ('', str)
+    RGW_API_PORT = (80, int)
+    RGW_API_ACCESS_KEY = ('', str)
+    RGW_API_SECRET_KEY = ('', str)
+    RGW_API_ADMIN_RESOURCE = ('admin', str)
+    RGW_API_USER_ID = ('', str)
+    RGW_API_SCHEME = ('http', str)
+
+
+class SettingsMeta(type):
+
+    def __getattribute__(cls, attr):
+        if not attr.startswith('_') and hasattr(Options, attr):
+            default, stype = getattr(Options, attr)
+            return stype(SettingsMeta.mgr.get_config(attr, default))
+        return SettingsMeta.__dict__.get(attr, None)
+
+    def __setattr__(cls, attr, value):
+        if not attr.startswith('_') and hasattr(Options, attr):
+            SettingsMeta.mgr.set_config(attr, str(value))
+        else:
+            setattr(SettingsMeta, attr, value)
+
+
+# pylint: disable=no-init
+class Settings(with_metaclass(SettingsMeta, object)):
+    pass
+
+
+def _options_command_map():
+    def filter_attr(member):
+        return not inspect.isroutine(member)
+
+    cmd_map = {}
+    for option, value in inspect.getmembers(Options, filter_attr):
+        if option.startswith('_'):
+            continue
+        key_get = 'dashboard get-{}'.format(option.lower().replace('_', '-'))
+        key_set = 'dashboard set-{}'.format(option.lower().replace('_', '-'))
+        cmd_map[key_get] = {'name': option, 'type': None}
+        cmd_map[key_set] = {'name': option, 'type': value[1]}
+    return cmd_map
+
+
+_OPTIONS_COMMAND_MAP = _options_command_map()
+
+
+def options_command_list():
+    """
+    This function generates a list of ``get`` and ``set`` commands
+    for each declared configuration option in class ``Options``.
+    """
+    def py2ceph(pytype):
+        if pytype == str:
+            return 'CephString'
+        elif pytype == int:
+            return 'CephInt'
+        return 'CephString'
+
+    cmd_list = []
+    for cmd, opt in _OPTIONS_COMMAND_MAP.items():
+        if not opt['type']:
+            cmd_list.append({
+                'cmd': '{}'.format(cmd),
+                'desc': 'Get the {} option value'.format(opt['name']),
+                'perm': 'r'
+            })
+        else:
+            cmd_list.append({
+                'cmd': '{} name=value,type={}'
+                       .format(cmd, py2ceph(opt['type'])),
+                'desc': 'Set the {} option value'.format(opt['name']),
+                'perm': 'w'
+            })
+
+    return cmd_list
+
+
+def handle_option_command(cmd):
+    if cmd['prefix'] not in _OPTIONS_COMMAND_MAP:
+        return (-errno.EINVAL, '', "Command not found '{}'"
+                                   .format(cmd['prefix']))
+
+    opt = _OPTIONS_COMMAND_MAP[cmd['prefix']]
+    if not opt['type']:
+        # get option
+        return 0, str(getattr(Settings, opt['name'])), ''
+
+    # set option
+    setattr(Settings, opt['name'], opt['type'](cmd['value']))
+    return 0, 'Option {} updated'.format(opt['name']), ''

--- a/src/pybind/mgr/dashboard_v2/tests/helper.py
+++ b/src/pybind/mgr/dashboard_v2/tests/helper.py
@@ -41,7 +41,7 @@ class ControllerTestCase(helper.CPWebCase, RequestHelper):
     def setup_server(cls):
         module = Module('dashboard', None, None)
         cls._mgr_module = module
-        module.configure_cherrypy(True)
+        module.configure_module(True)
         cls.setup_test()
 
     @classmethod

--- a/src/pybind/mgr/dashboard_v2/tests/test_settings.py
+++ b/src/pybind/mgr/dashboard_v2/tests/test_settings.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+import errno
+import unittest
+
+from ..module import Module
+from ..settings import Settings
+
+
+class SettingsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        module = Module('dashboard', None, None)
+        module.configure_module(True)
+        cls.module = module
+
+    def setUp(self):
+        if Settings.GRAFANA_API_HOST != 'localhost':
+            Settings.GRAFANA_API_HOST = 'localhost'
+        if Settings.GRAFANA_API_PORT != 3000:
+            Settings.GRAFANA_API_PORT = 3000
+
+    def test_get_setting(self):
+        self.assertEqual(Settings.GRAFANA_API_HOST, 'localhost')
+
+    def test_set_setting(self):
+        Settings.GRAFANA_API_HOST = 'grafanahost'
+        self.assertEqual(Settings.GRAFANA_API_HOST, 'grafanahost')
+
+    def test_get_cmd(self):
+        r, out, err = self.module.handle_command(
+                {'prefix': 'dashboard get-grafana-api-port'})
+        self.assertEqual(r, 0)
+        self.assertEqual(out, '3000')
+        self.assertEqual(err, '')
+
+    def test_set_cmd(self):
+        r, out, err = self.module.handle_command(
+                {'prefix': 'dashboard set-grafana-api-port',
+                 'value': '4000'})
+        self.assertEqual(r, 0)
+        self.assertEqual(out, 'Option GRAFANA_API_PORT updated')
+        self.assertEqual(err, '')
+
+    def test_inv_cmd(self):
+        r, out, err = self.module.handle_command(
+                {'prefix': 'dashboard get-non-existent-option'})
+        self.assertEqual(r, -errno.EINVAL)
+        self.assertEqual(out, '')
+        self.assertEqual(err, "Command not found "
+                              "'dashboard get-non-existent-option'")
+
+    def test_sync(self):
+        Settings.GRAFANA_API_PORT = 5000
+        r, out, err = self.module.handle_command(
+                {'prefix': 'dashboard get-grafana-api-port'})
+        self.assertEqual(r, 0)
+        self.assertEqual(out, '5000')
+        self.assertEqual(err, '')
+        r, out, err = self.module.handle_command(
+                {'prefix': 'dashboard set-grafana-api-host',
+                 'value': 'new-local-host'})
+        self.assertEqual(r, 0)
+        self.assertEqual(out, 'Option GRAFANA_API_HOST updated')
+        self.assertEqual(err, '')
+        self.assertEqual(Settings.GRAFANA_API_HOST, 'new-local-host')


### PR DESCRIPTION
This PR adds the infrastructure to manage configuration settings in an easy way. For more information check the additions to the `README.rst` file.

This is also setting the ground for the implementation of the settings page.

Signed-off-by: Ricardo Dias <rdias@suse.com>