### PR TITLE
mgr/dashboard_v2: Don't use localized config for auth

### DIFF
--- a/src/pybind/mgr/dashboard_v2/controllers/auth.py
+++ b/src/pybind/mgr/dashboard_v2/controllers/auth.py
@@ -28,8 +28,8 @@ class Auth(RESTController):
     @RESTController.args_from_json
     def create(self, username, password, stay_signed_in=False):
         now = time.time()
-        config_username = self.mgr.get_localized_config('username', None)
-        config_password = self.mgr.get_localized_config('password', None)
+        config_username = self.mgr.get_config('username', None)
+        config_password = self.mgr.get_config('password', None)
         hash_password = Auth.password_hash(password,
                                            config_password)
         if username == config_username and hash_password == config_password:
@@ -66,7 +66,7 @@ class Auth(RESTController):
             raise cherrypy.HTTPError(401, 'You are not authorized to access '
                                           'that resource')
         now = time.time()
-        expires = float(Auth.mgr.get_localized_config(
+        expires = float(Auth.mgr.get_config(
             'session-expire', Session.DEFAULT_EXPIRE))
         if expires > 0:
             username_ts = cherrypy.session.get(Session.TS, None)
@@ -81,6 +81,6 @@ class Auth(RESTController):
 
     @staticmethod
     def set_login_credentials(username, password):
-        Auth.mgr.set_localized_config('username', username)
+        Auth.mgr.set_config('username', username)
         hashed_passwd = Auth.password_hash(password)
-        Auth.mgr.set_localized_config('password', hashed_passwd)
+        Auth.mgr.set_config('password', hashed_passwd)

--- a/src/pybind/mgr/dashboard_v2/tests/test_auth.py
+++ b/src/pybind/mgr/dashboard_v2/tests/test_auth.py
@@ -27,21 +27,19 @@ class AuthTest(ControllerTestCase):
     def setup_test(cls):
         cherrypy.tree.mount(Ping(), "/api/test",
                             config={'/': {'tools.authenticate.on': True}})
-        cls._mgr_module.set_localized_config('session-expire', '2')
-        cls._mgr_module.set_localized_config('username', 'admin')
-        cls._mgr_module.set_localized_config('password',
-                                             Auth.password_hash('admin'))
+        cls._mgr_module.set_config('session-expire', '2')
+        cls._mgr_module.set_config('username', 'admin')
+        cls._mgr_module.set_config('password', Auth.password_hash('admin'))
 
     def setUp(self):
-        self._mgr_module.set_localized_config('session-expire', '2')
-        self._mgr_module.set_localized_config('username', 'admin')
-        self._mgr_module.set_localized_config('password',
-                                              Auth.password_hash('admin'))
+        self._mgr_module.set_config('session-expire', '2')
+        self._mgr_module.set_config('username', 'admin')
+        self._mgr_module.set_config('password', Auth.password_hash('admin'))
 
     def test_a_set_login_credentials(self):
         Auth.set_login_credentials('admin2', 'admin2')
-        user = self._mgr_module.get_localized_config('username')
-        passwd = self._mgr_module.get_localized_config('password')
+        user = self._mgr_module.get_config('username')
+        passwd = self._mgr_module.get_config('password')
         self.assertEqual(user, 'admin2')
         self.assertEqual(passwd, Auth.password_hash('admin2', passwd))
 


### PR DESCRIPTION
According to https://github.com/openattic/ceph/pull/46#issuecomment-361580919, login credentials should be stored on configuration, instead of localized configuration.

Signed-off-by: Ricardo Marques <rimarques@suse.com>