### PR TITLE
mgr/dashboard_v2: Fixed Exception in settings module when loaded by mgr

### DIFF
--- a/src/pybind/mgr/dashboard_v2/settings.py
+++ b/src/pybind/mgr/dashboard_v2/settings.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import errno
 import inspect
-from six import with_metaclass
+from six import add_metaclass
 
 
 class Options(object):
@@ -43,8 +43,8 @@ class SettingsMeta(type):
             setattr(SettingsMeta, attr, value)
 
 
-# pylint: disable=no-init
-class Settings(with_metaclass(SettingsMeta, object)):
+@add_metaclass(SettingsMeta)
+class Settings(object):
     pass
 
 


### PR DESCRIPTION
Even if the code should do the same, it fixes an exception in the mgr log:

```
2018-02-01 17:41:06.182 7f9af498c700 -1 mgr load_subclass_of Traceback (most recent call last):
  File "/ceph/src/pybind/mgr/dashboard_v2/__init__.py", line 24, in <module>
    from .module import *  # NOQA
  File "/ceph/src/pybind/mgr/dashboard_v2/module.py", line 16, in <module>
    from .settings import Settings, options_command_list, handle_option_command
  File "/ceph/src/pybind/mgr/dashboard_v2/settings.py", line 47, in <module>
    class Settings(with_metaclass(SettingsMeta, object)):
TypeError: Error when calling the metaclass bases
    'NoneType' object is not callable
```

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>