### PR TITLE
mgr/dashboard_v2: lazy initialization of controllers

### DIFF
--- a/src/pybind/mgr/dashboard_v2/README.rst
+++ b/src/pybind/mgr/dashboard_v2/README.rst
@@ -309,3 +309,34 @@ can be used:
 * ``health``: health status regular update
 * ``pg_summary``: regular update of PG status information
 
+
+Where to place the initialization code of a controller?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Your controllers might need to execute some initialization code before starting
+answering to requests, for instance if you need to cache some data beforehand.
+
+In ``BaseController`` there is a method called ``init()``, which can be
+overriden by subclasses, that will execute upon the first request made to the
+controller.
+
+This means that if a controller is never requested, its initialization code
+will never need to be executed as well.
+
+Example::
+
+  import cherrypy
+  from ..tools import BaseController, ApiController
+
+  @ApiController('ping3')
+  class Ping3(BaseController):
+    prefix = None
+
+    def init(self):
+      self.prefix = 'myping'
+
+    @cherrypy.expose
+    def default(self, *args):
+      return '{}: Hello'.format(self.prefix)
+
+

--- a/src/pybind/mgr/dashboard_v2/controllers/ping.py
+++ b/src/pybind/mgr/dashboard_v2/controllers/ping.py
@@ -16,9 +16,14 @@ class Ping(BaseController):
 
 @ApiController('echo1')
 class EchoArgs(RESTController):
+    prefix = None
+
+    def init(self):
+        self.prefix = "ea"
+
     @RESTController.args_from_json
     def create(self, msg):
-        return {'echo': msg}
+        return {'echo': "{}: {}".format(self.prefix, msg)}
 
 
 @ApiController('echo2')

--- a/src/pybind/mgr/dashboard_v2/tests/test_ping.py
+++ b/src/pybind/mgr/dashboard_v2/tests/test_ping.py
@@ -24,4 +24,4 @@ class PingTest(ControllerTestCase):
     def test_echo_args(self):
         self._post("/api/echo1", {'msg': 'Hello World'})
         self.assertStatus('201 Created')
-        self.assertJsonBody({'echo': 'Hello World'})
+        self.assertJsonBody({'echo': 'ea: Hello World'})

--- a/src/pybind/mgr/dashboard_v2/tools.py
+++ b/src/pybind/mgr/dashboard_v2/tools.py
@@ -106,6 +106,26 @@ class BaseController(six.with_metaclass(BaseControllerMeta, object)):
         'request.error_page': {'default': json_error_page},
     }
 
+    def __init__(self):
+        self._initialized = False
+
+    def __getattribute__(self, attr):
+        obj = super(BaseController, self).__getattribute__(attr)
+        if inspect.ismethod(obj) and hasattr(obj, 'exposed') and obj.exposed \
+                and not self._initialized:
+            self.init()
+            self._initialized = True
+        return obj
+
+    def init(self):
+        """Controller lazy initialization
+
+        All the controller initialization code should be put in this method,
+        which will be executed upon the first HTTP request made to this
+        controller.
+        """
+        pass
+
     @property
     def mgr(self):
         """


### PR DESCRIPTION
This PR adds a new instance method to `BaseController` class called `init()` that can be used by controllers to add its initialization code.
This `init()` method will only be called upon the first time that a request is made to the controller.

The reason to put the initialization code inside the `init()` method instead of the `__init__` constructor method is because the controller constructor will be called during the automatic controller loading mechanism, and if this constructor is running code that makes calls to the manager `send_command` method for instance, when running a single unit test it will execute that command, and there is no easy way to mock it, neither to know what response we may need for the mock object.

With this lazy initialization, only the unit test of the respective controller, will trigger the initialization of the controller, and can easily mock the manager methods by adding a decorator `@patch` to the test instance method.

Signed-off-by: Ricardo Dias <rdias@suse.com>
