### PR TITLE
mgr/dashboard_v2: Move hosts option to cluster menu

### DIFF
--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/app.component.html
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/app.component.html
@@ -1,6 +1,5 @@
 <cd-navigation *ngIf="!isLoginActive()"></cd-navigation>
 <div class="container-fluid"
      [ngClass]="{'full-height':isLoginActive()}">
-  <div *ngIf="!isLoginActive()" class="breadcrumb"></div>
   <router-outlet></router-outlet>
 </div>

--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/cluster/hosts/hosts.component.html
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/cluster/hosts/hosts.component.html
@@ -1,3 +1,9 @@
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+    <li class="breadcrumb-item">Cluster</li>
+    <li class="breadcrumb-item active">Hosts</li>
+  </ol>
+</nav>
 <table class="table table-bordered">
   <thead>
   <tr>

--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/core/navigation/navigation/navigation.component.html
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/core/navigation/navigation/navigation.component.html
@@ -50,11 +50,25 @@
         </a>
       </li>
       -->
-      <li routerLinkActive="active"
-          class="tc_menuitem tc_menuitem_ceph_nodes">
-        <a i18n
-           routerLink="/hosts">Hosts
+      <li dropdown
+          routerLinkActive="active"
+          class="dropdown tc_menuitem tc_menuitem_cluster">
+        <a dropdownToggle
+           class="dropdown-toggle"
+           data-toggle="dropdown">
+          <ng-container i18n>Cluster</ng-container>
+          <span class="caret"></span>
         </a>
+        <ul *dropdownMenu
+            class="dropdown-menu">
+          <li routerLinkActive="active"
+              class="tc_submenuitem tc_submenuitem_hosts">
+            <a i18n
+               class="dropdown-item"
+               routerLink="/hosts">Hosts
+            </a>
+          </li>
+        </ul>
       </li>
       <!--<li class="dropdown tc_menuitem tc_menuitem_ceph_rgw">
         <a href=""


### PR DESCRIPTION
This PR moves de "Hosts" menu to a submenu inside "Cluster" menu, to match the existing structure of the dashboard v1.

Dashboad v1

![screenshot from 2018-02-02 13-06-48](https://user-images.githubusercontent.com/14297426/35734783-35b49cea-081a-11e8-9bcb-167c3cff8ca8.png)

Dashboad v2

![screenshot from 2018-02-02 13-07-17](https://user-images.githubusercontent.com/14297426/35734800-4293be50-081a-11e8-8aa4-865f38cbf0ec.png)

This PR will also add a breadcrum to the Hosts page:

![screenshot from 2018-02-02 13-19-46](https://user-images.githubusercontent.com/14297426/35735293-0f982b6a-081c-11e8-96f7-d9dff8e7a348.png)

Signed-off-by: Ricardo Marques <rimarques@suse.com>