### PR TITLE
mgr/dashboard_v2: Mocking of RADOS and RBD modules 

### DIFF
--- a/src/pybind/mgr/dashboard_v2/.pylintrc
+++ b/src/pybind/mgr/dashboard_v2/.pylintrc
@@ -3,7 +3,7 @@
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
-extension-pkg-whitelist=
+extension-pkg-whitelist=rados,rbd
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.

--- a/src/pybind/mgr/dashboard_v2/README.rst
+++ b/src/pybind/mgr/dashboard_v2/README.rst
@@ -309,3 +309,37 @@ can be used:
 * ``health``: health status regular update
 * ``pg_summary``: regular update of PG status information
 
+
+How to write a unit test when a controller accesses a Ceph module?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Consider the following example that implements a controller that retrieves the
+list of RBD images of the ``rbd`` pool::
+
+  import rbd
+  from ..tools import ApiController, RESTController
+
+  @ApiController('rbdimages')
+  class RbdImages(RESTController):
+      def __init__(self):
+          self.ioctx = self.mgr.rados.open_ioctx('rbd')
+          self.rbd = rbd.RBD()
+
+      def list(self):
+          return [{'name': n} for n in self.rbd.list(self.ioctx)]
+
+In the example above, we want to mock the return value of the ``rbd.list``
+function, so that we can test the JSON response of the controller.
+
+The unit test code will look like the following::
+
+  import mock
+  from .helper import ControllerTestCase
+
+  class RbdImagesTest(ControllerTestCase):
+      @mock.patch('rbd.RBD.list')
+      def test_list(self, rbd_list_mock):
+          rbd_list_mock.return_value = ['img1', 'img2']
+          self._get('/api/rbdimages')
+          self.assertJsonBody([{'name': 'img1'}, {'name': 'img2'}])
+

--- a/src/pybind/mgr/dashboard_v2/__init__.py
+++ b/src/pybind/mgr/dashboard_v2/__init__.py
@@ -26,8 +26,10 @@ else:
     import logging
     import sys
     # pylint: disable=W0403
-    from . import ceph_module_mock
+    from .cephmock import ceph_module_mock, rados_mock, rbd_mock
     sys.modules['ceph_module'] = ceph_module_mock
+    sys.modules['rados'] = rados_mock
+    sys.modules['rbd'] = rbd_mock
     logging.basicConfig(level=logging.WARNING)
     logger = logging.getLogger(__name__)
     logging.root.handlers[0].setLevel(logging.WARNING)

--- a/src/pybind/mgr/dashboard_v2/cephmock/ceph_module_mock.py
+++ b/src/pybind/mgr/dashboard_v2/cephmock/ceph_module_mock.py
@@ -36,3 +36,6 @@ class BaseMgrModule(object):
 
     def _ceph_log(self, *args):
         pass
+
+    def _ceph_get_context(self):
+        return None

--- a/src/pybind/mgr/dashboard_v2/cephmock/rados_mock.py
+++ b/src/pybind/mgr/dashboard_v2/cephmock/rados_mock.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+
+class Rados(object):
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def connect(self):
+        pass
+
+    def open_ioctx(self, pool_name):
+        pass

--- a/src/pybind/mgr/dashboard_v2/cephmock/rbd_mock.py
+++ b/src/pybind/mgr/dashboard_v2/cephmock/rbd_mock.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+
+RBD_FEATURE_LAYERING = "RBD_FEATURE_LAYERING"
+RBD_FEATURE_STRIPINGV2 = "RBD_FEATURE_STRIPINGV2"
+RBD_FEATURE_EXCLUSIVE_LOCK = "RBD_FEATURE_EXCLUSIVE_LOCK"
+RBD_FEATURE_OBJECT_MAP = "RBD_FEATURE_OBJECT_MAP"
+RBD_FEATURE_FAST_DIFF = "RBD_FEATURE_FAST_DIFF"
+RBD_FEATURE_DEEP_FLATTEN = "RBD_FEATURE_DEEP_FLATTEN"
+RBD_FEATURE_JOURNALING = "RBD_FEATURE_JOURNALING"
+RBD_FEATURE_DATA_POOL = "RBD_FEATURE_DATA_POOL"
+RBD_FEATURE_OPERATIONS = "RBD_FEATURE_OPERATIONS"
+
+
+class RBD(object):
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def list(self, ioctx):
+        pass
+
+
+class Image(object):
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def stat(self):
+        pass
+
+    def features(self):
+        pass

--- a/src/pybind/mgr/dashboard_v2/tox.ini
+++ b/src/pybind/mgr/dashboard_v2/tox.ini
@@ -8,6 +8,8 @@ setenv=
     UNITTEST=true
     WEBTEST_INTERACTIVE=false
     COVERAGE_FILE= .coverage.{envname}
+    PYTHONPATH = {toxinidir}/../../../../build/lib/cython_modules/lib.3:{toxinidir}/../../../../build/lib/cython_modules/lib.2
+    LD_LIBRARY_PATH = {toxinidir}/../../../../build/lib
 commands=
     {envbindir}/py.test --cov=. --cov-report= --junitxml=junit.{envname}.xml tests/
 
@@ -28,7 +30,10 @@ commands =
     coverage xml
 
 [testenv:lint]
+setenv =
+    PYTHONPATH = {toxinidir}/../../../../build/lib/cython_modules/lib.3:{toxinidir}/../../../../build/lib/cython_modules/lib.2
+    LD_LIBRARY_PATH = {toxinidir}/../../../../build/lib
 deps=-r{toxinidir}/requirements.txt
 commands=
-    pylint --rcfile=.pylintrc --jobs=5 . module.py tools.py ceph_module_mock.py controllers models tests
+    pylint --rcfile=.pylintrc --jobs=5 . module.py tools.py controllers models tests cephmock
     pycodestyle --max-line-length=100 --exclude=python2.7,.tox,venv,frontend .


### PR DESCRIPTION
This PR adds mock classes for the RADOS and RBD modules.

By adding this mocks we are also adding a maintenance burden to keep the mocks in sync with the real Ceph modules. But while we don't find a better solution we should merge this PR to make our jenkins job green again.

I also added to the README some instructions on how to write a unit test that mocks the result of a function of a ceph module.

Signed-off-by: Ricardo Dias <rdias@suse.com>