### PR TITLE
mgr/dashboard_v2: fix frontend bug in table.component.html

### DIFF
--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/components/table/table.component.html
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/components/table/table.component.html
@@ -52,7 +52,7 @@
                  [cssClasses]="paginationClasses"
                  [selectionType]="selectable"
                  [selected]="selected"
-                 (select)="toggleExpandRow($event)"
+                 (select)="toggleExpandRow()"
                  [columns]="columns"
                  [columnMode]="columnMode"
                  [rows]="rows"
@@ -62,7 +62,7 @@
                  [loadingIndicator]="true"
                  [rowHeight]="'auto'">
     <!-- Row Detail Template -->
-    <ngx-datatable-row-detail (toggle)="updateDetailView($event)">
+    <ngx-datatable-row-detail (toggle)="updateDetailView()">
     </ngx-datatable-row-detail>
   </ngx-datatable>
 </div>


### PR DESCRIPTION
This bug was triggered when building the frontend in production mode:
`npm build -- --prod`

```
ERROR in src/app/shared/components/table/table.component.html(55,18): : Expected 0 arguments, but got 1.
src/app/shared/components/table/table.component.html(65,31): : Expected 0 arguments, but got 1.
```

Signed-off-by: Ricardo Dias <rdias@suse.com>