### PR TITLE
mgr/dashboard_v2: Ceph packaging process integration

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -358,6 +358,12 @@ Requires:       python%{_python_buildid}-jinja2
 Requires:       python%{_python_buildid}-pecan
 Requires:       python%{_python_buildid}-werkzeug
 Requires:       pyOpenSSL%{_python_buildid}
+%if 0%{?fedora}
+Requires:	python%{_python_buildid}-bcrypt
+%endif
+%if 0%{?rhel}
+Requires:	py-bcrypt
+%endif
 %endif
 %if 0%{?suse_version}
 Requires:       python%{_python_buildid}-CherryPy
@@ -365,9 +371,9 @@ Requires:       python%{_python_buildid}-Jinja2
 Requires:       python%{_python_buildid}-Werkzeug
 Requires:       python%{_python_buildid}-pecan
 Requires:       python%{_python_buildid}-pyOpenSSL
+Requires:       python%{_python_buildid}-bcrypt
 Recommends:     python%{_python_buildid}-influxdb
 %endif
-Requires:	python%{_python_buildid}-bcrypt
 %description mgr
 ceph-mgr enables python modules that provide services (such as the REST
 module derived from Calamari) and expose CLI hooks.  ceph-mgr gathers

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -100,6 +100,62 @@ EOF
     fi
 }
 
+function ensure_min_npm_version {
+  local install_npm_pkg_cmd=$1
+
+  if ! type npm > /dev/null 2>&1; then
+    $SUDO $install_npm_pkg_cmd
+  fi
+
+  NODE_VER=`node -v`
+  NODE_VER_MAJOR=`node -v | sed 's/v\(\w\+\).*/\1/g'`
+  NODE_VER_MINOR=`node -v | sed 's/v\w\+\.\(\w\+\).*/\1/g'`
+
+  # The minimum node version required is 4.8.0 so that we can use yarn below
+  UPDATE_NODE=false
+  if [ $NODE_VER_MAJOR -lt 4 ]; then
+    UPDATE_NODE=true
+  elif [ $NODE_VER_MAJOR -eq 4 ] && [ $NODE_VER_MINOR -lt 8 ]; then
+    UPDATE_NODE=true
+  fi
+  if $UPDATE_NODE; then
+    npm install -g n
+    n 4.8.0  # installs nodejs version 4.8.0
+    npm uninstall -g n
+    hash -d node > /dev/null 2>&1 || true
+  fi
+
+  NPM_VER=`npm -v`
+  NPM_VER_MAJOR=`npm -v | sed 's/\(\w\+\).*/\1/g'`
+
+  # The minimum npm version required is 5.0.0 so that we can install and use
+  # a local nodejs installation (required by the dashboard angular2 frontend)
+  if [ $NPM_VER_MAJOR -lt 5 ]; then
+    $SUDO npm install -g yarn
+    $SUDO yarn global add npm@^5.0.0  # install npm version 5.0.0 or later
+  fi
+  hash -d npm > /dev/null 2>&1
+
+  NEW_NODE_VER=`node -v`
+  NEW_NPM_VER=`npm -v`
+  if [ ! "$NODE_VER" = "$NEW_NODE_VER" ]; then
+cat <<EOF
+*****************************************************************************
+      YOUR NODE VERSION WAS UPDATED FROM $NODE_VER TO $NEW_NODE_VER
+*****************************************************************************
+EOF
+  fi
+  if [ ! "$NPM_VER" = "$NEW_NPM_VER" ]; then
+cat <<EOF
+*****************************************************************************
+      YOUR NPM VERSION WAS UPDATED FROM $NPM_VER TO $NEW_NPM_VER
+      TO RETURN TO VERSION $NPM_VER run the following command:
+          $ $SUDO yarn global remove npm && hash -d npm
+*****************************************************************************
+EOF
+  fi
+}
+
 if [ x`uname`x = xFreeBSDx ]; then
     $SUDO pkg install -yq \
         devel/babeltrace \
@@ -185,6 +241,9 @@ else
 	$SUDO env DEBIAN_FRONTEND=noninteractive mk-build-deps --install --remove --tool="apt-get -y --no-install-recommends $backports" $control || exit 1
 	$SUDO env DEBIAN_FRONTEND=noninteractive apt-get -y remove ceph-build-deps
 	if [ -n "$backports" ] ; then rm $control; fi
+        $SUDO env DEBIAN_FRONTEND=noninteractive apt-get -y install python-coverage python-tox nodejs
+        [ ! -e /usr/bin/node ] && $SUDO env DEBIAN_FRONTEND=noninteractive apt-get -y install nodejs-legacy
+        ensure_min_npm_version "env DEBIAN_FRONTEND=noninteractive apt-get -y install npm"
         ;;
     centos|fedora|rhel|ol|virtuozzo)
         yumdnf="yum"
@@ -206,6 +265,7 @@ else
                 if test $yumdnf = yum; then
                     $SUDO $yumdnf install -y yum-utils
                 fi
+                $SUDO $yumdnf install -y python-bcrypt
                 ;;
             CentOS|RedHatEnterpriseServer|VirtuozzoLinux)
                 $SUDO yum install -y yum-utils
@@ -237,6 +297,7 @@ else
                 elif test $(lsb_release -si) = VirtuozzoLinux -a $MAJOR_VERSION = 7 ; then
                     $SUDO yum-config-manager --enable cr
                 fi
+                $SUDO $yumdnf install -y py-bcrypt
                 ;;
         esac
         munge_ceph_spec_in $DIR/ceph.spec
@@ -245,12 +306,16 @@ else
             ensure_decent_gcc_on_rh $dts_ver
 	fi
         ! grep -q -i error: $DIR/yum-builddep.out || exit 1
+        $SUDO $yumdnf install -y python-coverage python-tox
+        ensure_min_npm_version "$yumdnf install -y npm"
         ;;
     opensuse|suse|sles)
         echo "Using zypper to install dependencies"
         $SUDO zypper --gpg-auto-import-keys --non-interactive install lsb-release systemd-rpm-macros
         munge_ceph_spec_in $DIR/ceph.spec
         $SUDO zypper --non-interactive install $(rpmspec -q --buildrequires $DIR/ceph.spec) || exit 1
+        $SUDO zypper --non-interactive install python-bcrypt python-coverage python-tox
+        ensure_min_npm_version "zypper --non-interactive install npm"
         ;;
     alpine)
         # for now we need the testing repo for leveldb

--- a/make-dist
+++ b/make-dist
@@ -61,6 +61,14 @@ download_boost() {
     rm -rf src/boost
 }
 
+build_dashboard_frontend() {
+  pushd src/pybind/mgr/dashboard_v2/frontend
+  npm install
+  npm run build -- --prod
+  popd
+  tar cf dashboard_frontend.tar $outfile/src/pybind/mgr/dashboard_v2/frontend/dist
+}
+
 # clean out old cruft...
 echo "cleanup..."
 rm -f $outfile*
@@ -113,9 +121,11 @@ download_boost $boost_version b2dfbd6c717be4a7bb2d88018eaccf75 \
                https://dl.bintray.com/boostorg/release/$boost_version/source \
                https://downloads.sourceforge.net/project/boost/boost/$boost_version \
                https://download.ceph.com/qa
+build_dashboard_frontend
 tar --concatenate -f $outfile.all.tar $outfile.version.tar
 tar --concatenate -f $outfile.all.tar $outfile.boost.tar
 tar --concatenate -f $outfile.all.tar $outfile.tar
+tar --concatenate -f $outfile.all.tar dashboard_frontend.tar
 mv $outfile.all.tar $outfile.tar
 rm $outfile
 rm -f $outfile.version.tar

--- a/src/pybind/mgr/dashboard_v2/.gitignore
+++ b/src/pybind/mgr/dashboard_v2/.gitignore
@@ -6,7 +6,7 @@ junit*xml
 __pycache__
 .cache
 ceph.conf
-wheelhouse
+wheelhouse*
 
 # IDE
 .vscode

--- a/src/pybind/mgr/dashboard_v2/tox.ini
+++ b/src/pybind/mgr/dashboard_v2/tox.ini
@@ -36,6 +36,8 @@ setenv=
 commands =
     bash ../src/vstart.sh -n
     sleep 10
+    python ./bin/ceph mgr module disable dashboard_v2
+    sleep 5
     python ./bin/ceph config-key set mgr/dashboard_v2/x/server_port 9865
     python ./bin/ceph mgr module enable dashboard_v2
     cp ceph.conf {toxinidir}/


### PR DESCRIPTION
This PR adds the dashboard_v2 frontend build files to the Ceph dist tarball, plus it changes vstart.sh script to enable and configure the dashboard_v2 module.



Signed-off-by: Ricardo Dias <rdias@suse.com>