### PR TITLE
mgr/dashboard_v2: Fix tox warnings

### DIFF
--- a/src/pybind/mgr/dashboard_v2/.gitignore
+++ b/src/pybind/mgr/dashboard_v2/.gitignore
@@ -5,6 +5,7 @@ coverage.xml
 junit*xml
 __pycache__
 .cache
+ceph.conf
 
 # IDE
 .vscode

--- a/src/pybind/mgr/dashboard_v2/tox.ini
+++ b/src/pybind/mgr/dashboard_v2/tox.ini
@@ -26,9 +26,9 @@ commands =
 deps=coverage
 changedir={toxinidir}/../../../../build
 whitelist_externals=
-    /bin/bash
-    /bin/cp
-    /bin/sleep
+    bash
+    cp
+    sleep
 setenv=
     COVERAGE_ENABLED=true
     COVERAGE_FILE=.coverage.mgr
@@ -45,11 +45,11 @@ commands =
 deps=
 changedir={toxinidir}/../../../../build
 whitelist_externals=
-    /bin/bash
-    /bin/rm
-    /bin/mv
-    /usr/bin/killall
-    /bin/sleep
+    bash
+    rm
+    mv
+    killall
+    sleep
 commands =
     killall ceph-mgr
     sleep 5


### PR DESCRIPTION
Fix tox.ini to do not output the 'WARNING:test command found but not installed in testenv' message.

Signed-off-by: Volker Theile <vtheile@suse.com>