### PR TITLE
mgr/dashboard_v2: add node as a local dependency

### DIFF
--- a/src/pybind/mgr/dashboard_v2/frontend/package.json
+++ b/src/pybind/mgr/dashboard_v2/frontend/package.json
@@ -54,6 +54,7 @@
     "karma-jasmine-html-reporter": "^0.2.2",
     "karma-junit-reporter": "^1.2.0",
     "karma-phantomjs-launcher": "^1.0.4",
+    "node": "^8.9.4",
     "protractor": "~5.1.2",
     "ts-node": "~3.2.0",
     "tslint": "~5.9.1",


### PR DESCRIPTION
This will allow us to use the angular cli on systems that don't have node
v6.9.0 or higher installed.

Signed-off-by: Tiago Melo <tmelo@suse.com>