### PR TITLE
mgr/dashboard_v2: Highlight clickable datatable rows if mouse hovers over them

### DIFF
--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/components/datatable/table/table.component.scss
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/components/datatable/table/table.component.scss
@@ -130,6 +130,12 @@
   }
   .datatable-body {
     .datatable-body-row {
+      &.clickable:hover .datatable-row-group {
+        background-color: #eee;
+        transition-property: background;
+        transition-duration: .3s;
+        transition-timing-function: linear;
+      }
       &.datatable-row-even {
         background-color: #ffffff;
       }


### PR DESCRIPTION
A datatable has clickable rows if ``detailsComponent`` is set.

Signed-off-by: Volker Theile <vtheile@suse.com>
