### PR TITLE
mgr/dashboard_v2/frontend: fix visibility of class properties

### DIFF
--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.ts
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.ts
@@ -13,8 +13,8 @@ import { TablePerformanceCounterService } from '../services/table-performance-co
 })
 export class TablePerformanceCounterComponent implements OnInit {
 
-  private columns: Array<CdTableColumn> = [];
-  private counters: Array<object> = [];
+  columns: Array<CdTableColumn> = [];
+  counters: Array<object> = [];
 
   @ViewChild('valueTpl') public valueTpl: TemplateRef<any>;
 

--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.ts
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.ts
@@ -11,8 +11,8 @@ import { RgwDaemonService } from '../services/rgw-daemon.service';
 })
 export class RgwDaemonDetailsComponent implements OnInit {
 
-  private metadata: Array<object> = [];
-  private serviceId = '';
+  metadata: Array<object> = [];
+  serviceId = '';
 
   @Input() selected?: Array<any> = [];
 

--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.ts
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.ts
@@ -11,8 +11,8 @@ import { RgwDaemonService } from '../services/rgw-daemon.service';
 })
 export class RgwDaemonListComponent implements OnInit {
 
-  private columns: Array<CdTableColumn> = [];
-  private daemons: Array<object> = [];
+  columns: Array<CdTableColumn> = [];
+  daemons: Array<object> = [];
 
   detailsComponent = 'RgwDaemonDetailsComponent';
 

--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/components/datatable/table-key-value/table-key-value.component.ts
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/components/datatable/table-key-value/table-key-value.component.ts
@@ -18,7 +18,7 @@ import { CdTableColumn } from '../../../models/cd-table-column';
 })
 export class TableKeyValueComponent implements OnInit {
 
-  private columns: Array<CdTableColumn> = [];
+  columns: Array<CdTableColumn> = [];
 
   /**
    * An array of objects to be displayed in the data table.


### PR DESCRIPTION
This PR fixes the frontend build in "production mode".
For some reason the frontend build in production mode runs more code checks than in development mode. 
(Maybe frontend guys could explain the reason for this behavior)

The error ouput of the build can be found below:

```
ERROR in src/app/shared/components/datatable/table-key-value/table-key-value.component.html(2,11): : Property 'columns' is private and only accessible within class 'TableKeyValueComponent'.
src/app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.html(1,11): : Property 'counters' is private and only accessible within class 'TablePerformanceCounterComponent'.
src/app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.html(2,11): : Property 'columns' is private and only accessible within class 'TablePerformanceCounterComponent'.
src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.html(6,11): : Property 'daemons' is private and only accessible within class 'RgwDaemonListComponent'.
src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.html(7,11): : Property 'columns' is private and only accessible within class 'RgwDaemonListComponent'.
src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.html(3,25): : Property 'metadata' is private and only accessible within class 'RgwDaemonDetailsComponent'.
src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.html(8,35): : Property 'serviceId' is private and only accessible within class 'RgwDaemonDetailsComponent'.
```

Signed-off-by: Ricardo Dias <rdias@suse.com>