### PR TITLE
mgr/dashboard_v2: Renamed `block_pool` controller to `rbd`

### DIFF
--- a/src/pybind/mgr/dashboard_v2/controllers/rbd.py
+++ b/src/pybind/mgr/dashboard_v2/controllers/rbd.py
@@ -1,20 +1,26 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import cherrypy
 import rbd
 
-from ..tools import ApiController, AuthRequired, BaseController, ViewCache
+from ..tools import ApiController, AuthRequired, RESTController, ViewCache
 
 
-@ApiController('block_pool')
+@ApiController('rbd')
 @AuthRequired()
-class BlockPool(BaseController):
+class Rbd(RESTController):
 
     def __init__(self):
         self.rbd = None
 
-    def _format_bitmask(self, features):
+    @staticmethod
+    def _format_bitmask(features):
+        """
+        Formats the bitmask:
+
+        >>> Rbd._format_bitmask(45)
+        'deep-flatten, exclusive-lock, layering, object-map'
+        """
         RBD_FEATURES_NAME_MAPPING = {
             rbd.RBD_FEATURE_LAYERING: "layering",
             rbd.RBD_FEATURE_STRIPINGV2: "striping",
@@ -55,9 +61,7 @@ class BlockPool(BaseController):
             result.append(stat)
         return result
 
-    @cherrypy.expose
-    @cherrypy.tools.json_out()
-    def rbd_pool_data(self, pool_name):
+    def get(self, pool_name):
         # pylint: disable=unbalanced-tuple-unpacking
         status, value = self._rbd_list(pool_name)
         if status == ViewCache.VALUE_EXCEPTION:

--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/services/pool.service.ts
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/services/pool.service.ts
@@ -8,7 +8,7 @@ export class PoolService {
   }
 
   rbdPoolImages(pool) {
-    return this.http.get(`/api/block_pool/rbd_pool_data/${pool}`).toPromise().then((resp: any) => {
+    return this.http.get(`/api/rbd/${pool}`).toPromise().then((resp: any) => {
       return resp;
     });
   }

--- a/src/pybind/mgr/dashboard_v2/tests/test_rbd.py
+++ b/src/pybind/mgr/dashboard_v2/tests/test_rbd.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 from .helper import ControllerTestCase, authenticate
 
 
-class BlockPoolTest(ControllerTestCase):
+class RbdTest(ControllerTestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -20,7 +20,7 @@ class BlockPoolTest(ControllerTestCase):
 
     @authenticate
     def test_list(self):
-        data = self._get('/api/block_pool/rbd_pool_data/rbd')
+        data = self._get('/api/rbd/rbd')
         self.assertStatus(200)
 
         img1 = data['value'][0]

--- a/src/pybind/mgr/dashboard_v2/tox.ini
+++ b/src/pybind/mgr/dashboard_v2/tox.ini
@@ -13,7 +13,7 @@ setenv=
     PATH = {toxinidir}/../../../../build/bin:$PATH
     DASHBOARD_V2_PORT=9865
 commands=
-    {envbindir}/py.test --cov=. --cov-report= --junitxml=junit.{envname}.xml tests/
+    {envbindir}/py.test --cov=. --cov-report= --junitxml=junit.{envname}.xml --doctest-modules controllers/rbd.py tests/
 
 [testenv:cov-init]
 setenv =


### PR DESCRIPTION
Also: 

* Simplified the API
* Fixed and improved the rbd controller tests.

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>