### PR TITLE
mgr/dashboard_v2: Add missing command 'install' to the HACKING file

### DIFF
--- a/src/pybind/mgr/dashboard_v2/HACKING.rst
+++ b/src/pybind/mgr/dashboard_v2/HACKING.rst
@@ -111,7 +111,7 @@ Backend Development
 The Python backend code of this module requires a number of Python modules to be
 installed. They are listed in file ``requirements.txt``. Using `pip
 <https://pypi.python.org/pypi/pip>`_ you may install all required dependencies
-by issuing ``pip -r requirements.txt`` in directory
+by issuing ``pip install -r requirements.txt`` in directory
 ``src/pybind/mgr/dashboard_v2``.
 
 If you're using the `ceph-dev-docker development environment


### PR DESCRIPTION
'install' was missing from the 'pip install -r requirements.txt'
command on our HACKING.rst file. Running the command without 'install'
is not correct and leads to an error.

Signed-off-by: Tatjana Dehler <tdehler@suse.com>