### PR TITLE
mgr/dashboard_v2: Data transform in k/v table

### DIFF
--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.ts
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.ts
@@ -11,7 +11,7 @@ import { RgwDaemonService } from '../services/rgw-daemon.service';
 })
 export class RgwDaemonDetailsComponent implements OnInit {
 
-  metadata: Array<object> = [];
+  metadata: any;
   serviceId = '';
 
   @Input() selected?: Array<any> = [];
@@ -29,19 +29,9 @@ export class RgwDaemonDetailsComponent implements OnInit {
     if (_.isEmpty(this.serviceId)) {
       return;
     }
-
     this.rgwDaemonService.get(this.serviceId)
       .then((resp) => {
-        const metadata = [];
-        const keys = _.keys(resp['rgw_metadata']);
-        keys.sort();
-        _.map(keys, (key) => {
-          metadata.push({
-            'key': key,
-            'value': resp['rgw_metadata'][key]
-          });
-        });
-        this.metadata = metadata;
+        this.metadata = resp['rgw_metadata'];
       });
   }
 }

--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/datatable/table-key-value/table-key-value.component.html
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/datatable/table-key-value/table-key-value.component.html
@@ -1,4 +1,4 @@
-<cd-table [data]="data"
+<cd-table [data]="tableData"
           [columns]="columns"
           columnMode="flex"
           [toolHeader]="false"

--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/datatable/table-key-value/table-key-value.component.spec.ts
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/datatable/table-key-value/table-key-value.component.spec.ts
@@ -23,10 +23,77 @@ describe('TableKeyValueComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(TableKeyValueComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should make key value object pairs out of arrays with length two', () => {
+    component.data = [
+      ['someKey', 0],
+      [3, 'something'],
+    ];
+    component.ngOnInit();
+    expect(component.tableData.length).toBe(2);
+    expect(component.tableData[0].key).toBe('someKey');
+    expect(component.tableData[1].value).toBe('something');
+  });
+
+  it('should transform arrays', () => {
+    component.data = [
+      ['someKey', [1, 2, 3]],
+      [3, 'something']
+    ];
+    component.ngOnInit();
+    expect(component.tableData.length).toBe(2);
+    expect(component.tableData[0].key).toBe('someKey');
+    expect(component.tableData[0].value).toBe('1, 2, 3');
+    expect(component.tableData[1].value).toBe('something');
+  });
+
+  it('should remove pure object values', () => {
+    component.data = [
+      [3, 'something'],
+      ['will be removed', { a: 3, b: 4, c: 5}]
+    ];
+    component.ngOnInit();
+    expect(component.tableData.length).toBe(1);
+    expect(component.tableData[0].value).toBe('something');
+  });
+
+  it('should make key value object pairs out of an object', () => {
+    component.data = {
+      3: 'something',
+      someKey: 0
+    };
+    component.ngOnInit();
+    expect(component.tableData.length).toBe(2);
+    expect(component.tableData[0].value).toBe('something');
+    expect(component.tableData[1].key).toBe('someKey');
+  });
+
+  it('should make do nothing if data is correct', () => {
+    component.data = [
+      {
+        key: 3,
+        value: 'something'
+      },
+      {
+        key: 'someKey',
+        value: 0
+      }
+    ];
+    component.ngOnInit();
+    expect(component.tableData.length).toBe(2);
+    expect(component.tableData[0].value).toBe('something');
+    expect(component.tableData[1].key).toBe('someKey');
+  });
+
+  it('should throw error if miss match', () => {
+    component.data = 38;
+    expect(() => component.ngOnInit()).toThrowError('Wrong data format');
+    component.data = [['someKey', 0, 3]];
+    expect(() => component.ngOnInit()).toThrowError('Wrong array format');
   });
 });

--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/datatable/table/table.component.html
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/datatable/table/table.component.html
@@ -53,6 +53,7 @@
                  [selectionType]="selectionType"
                  [selected]="selected"
                  (select)="toggleExpandRow()"
+                 [sorts]="sorts"
                  [columns]="columns"
                  [columnMode]="columnMode"
                  [rows]="rows"

--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/datatable/table/table.component.ts
@@ -12,7 +12,7 @@ import {
   ViewChild
 } from '@angular/core';
 
-import { DatatableComponent } from '@swimlane/ngx-datatable';
+import { DatatableComponent, SortDirection, SortPropDir } from '@swimlane/ngx-datatable';
 import * as _ from 'lodash';
 
 import { CdTableColumn } from '../../models/cd-table-column';
@@ -34,6 +34,8 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges {
   @Input() data: any[] = [];
   // Each item -> { prop: 'attribute name', name: 'display name' }
   @Input() columns: CdTableColumn[];
+  // Each item -> { prop: 'attribute name', dir: 'asc'||'desc'}
+  @Input() sorts?: SortPropDir[];
   // Method used for setting column widths.
   @Input() columnMode ?= 'force';
   // Name of the component e.g. 'TableDetailsComponent'
@@ -87,6 +89,14 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges {
     if (this.detailsComponent) {
       this.selectionType = 'multi';
     }
+    if (!this.sorts) {
+      this.sorts = [
+        {
+          prop: this.columns[0].prop,
+          dir: SortDirection.asc
+        }
+      ];
+    }
   }
 
   ngAfterContentChecked() {
@@ -97,8 +107,7 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges {
     // https://github.com/swimlane/ngx-datatable/issues/193#issuecomment-329144543
     if (this.table && this.table.element.clientWidth !== this.currentWidth) {
       this.currentWidth = this.table.element.clientWidth;
-      // Force the redrawing of the table.
-      window.dispatchEvent(new Event('resize'));
+      this.table.recalculate();
     }
   }
 
@@ -128,6 +137,9 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges {
   }
 
   useData() {
+    if (!this.data) {
+      return; // Wait for data
+    }
     this.rows = [...this.data];
     this.loadingIndicator = false;
   }


### PR DESCRIPTION
The key value table can transform the input data into key value objects
now, you don't have to care about that anymore.

Also the first column of the data used in cd-table will be sorted if
not set manual through the "sorts" array.

Signed-off-by: Stephan Müller <smueller@suse.com>