### PR TITLE
mgr/dashboard_v2: Add  bin dir to PATH

### DIFF
--- a/src/pybind/mgr/dashboard_v2/__init__.py
+++ b/src/pybind/mgr/dashboard_v2/__init__.py
@@ -25,3 +25,5 @@ else:
     logging.basicConfig(level=logging.DEBUG)
     logger = logging.getLogger(__name__)
     logging.root.handlers[0].setLevel(logging.DEBUG)
+    os.environ['PATH'] = '{}:{}'.format(os.path.abspath('../../../../build/bin'),
+                                        os.environ['PATH'])


### PR DESCRIPTION
Add `<repo>/build/bin` to `PATH` when running unit tests.

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>