### PR TITLE
mgr/dashboard_v2: Add links on dashboard

### DIFF
--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/dashboard/dashboard.module.ts
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/dashboard/dashboard.module.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
 
 import { ChartsModule } from 'ng2-charts';
 import { TabsModule } from 'ngx-bootstrap/tabs';
@@ -17,7 +18,7 @@ import { PgStatusStylePipe } from './pg-status-style.pipe';
 import { PgStatusPipe } from './pg-status.pipe';
 
 @NgModule({
-  imports: [CommonModule, TabsModule.forRoot(), SharedModule, ChartsModule],
+  imports: [CommonModule, TabsModule.forRoot(), SharedModule, ChartsModule, RouterModule],
   declarations: [
     HealthComponent,
     DashboardComponent,

--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/dashboard/health/health.component.html
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/dashboard/health/health.component.html
@@ -27,7 +27,7 @@
               </div>
               <div class="media-body">
                 <span class="media-heading"
-                      i18n="ceph monitors">Monitors</span>
+                      i18n="ceph monitors"><a routerLink="/monitor/">Monitors</a></span>
                 <span class="media-text">{{ contentData.mon_status | monSummary }}</span>
               </div>
             </div>
@@ -41,7 +41,7 @@
               </div>
               <div class="media-body">
                 <span class="media-heading"
-                      i18n="ceph OSDs">OSDs</span>
+                      i18n="ceph OSDs"><a routerLink="/osd/">OSDs</a></span>
                 <span class="media-text">{{ contentData.osd_map | osdSummary }}</span>
               </div>
             </div>


### PR DESCRIPTION
User will be able to navigate from dashboard to "Monitor" and "OSDs" pages

![screenshot from 2018-02-19 14-29-14](https://user-images.githubusercontent.com/14297426/36383067-ef53720a-1582-11e8-983c-82ed41d65e30.png)

Signed-off-by: Ricardo Marques <rimarques@suse.com>