### PR TITLE
mgr/dashboard_v2: Use monospace font on logs

### DIFF
--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/dashboard/health/health.component.html
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/dashboard/health/health.component.html
@@ -190,6 +190,7 @@
 
           <tabset>
             <tab heading="Cluster log"
+                 class="text-monospace"
                  i18n-heading>
               <span *ngFor="let line of contentData.clog">
                 {{ line.stamp }}&nbsp;{{ line.priority }}&nbsp;
@@ -200,6 +201,7 @@
               </span>
             </tab>
             <tab heading="Audit log"
+                 class="text-monospace"
                  i18n-heading>
               <span *ngFor="let line of contentData.audit_log">
                 {{ line.stamp }}&nbsp;{{ line.priority }}&nbsp;

--- a/src/pybind/mgr/dashboard_v2/frontend/src/openattic-theme.scss
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/openattic-theme.scss
@@ -111,6 +111,9 @@ option {
 .text-right {
   text-align: right;
 }
+.text-monospace {
+  font-family: monospace;
+}
 
 /* Branding */
 .navbar-openattic .navbar-brand,


### PR DESCRIPTION
This PR will change the font-family used to display logs, to monospace.

![screenshot from 2018-02-19 14-51-33](https://user-images.githubusercontent.com/14297426/36383604-8f7e67f2-1584-11e8-9454-0b8f182919f5.png)

Signed-off-by: Ricardo Marques <rimarques@suse.com>