### PR TITLE
mgr/dashboard_v2: Add NPM package node-bin-setup to dev dependency

### DIFF
--- a/src/pybind/mgr/dashboard_v2/frontend/package.json
+++ b/src/pybind/mgr/dashboard_v2/frontend/package.json
@@ -55,6 +55,7 @@
     "karma-junit-reporter": "^1.2.0",
     "karma-phantomjs-launcher": "^1.0.4",
     "node": "^8.9.4",
+    "node-bin-setup": "^1.0.6",
     "protractor": "~5.1.2",
     "ts-node": "~3.2.0",
     "tslint": "~5.9.1",


### PR DESCRIPTION
This will fix the following error when running ``npm install``.

```
# npm install
loadDevDep:node → headers ▀ ╢███████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░╟

> node@8.9.4 preinstall /home/vot/git/ceph/src/pybind/mgr/dashboard_v2/frontend/node_modules/.staging/node-240e42e7
> node installArchSpecificPackage

module.js:491
    throw err;
    ^

Error: Cannot find module 'node-bin-setup'
    at Function.Module._resolveFilename (module.js:489:15)
    at Function.Module._load (module.js:439:25)
    at Module.require (module.js:517:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/home/vot/git/ceph/src/pybind/mgr/dashboard_v2/frontend/node_modules/.staging/node-240e42e7/installArchSpecificPackage.js:1:63)
    at Module._compile (module.js:573:30)
    at Object.Module._extensions..js (module.js:584:10)
    at Module.load (module.js:507:32)
    at tryModuleLoad (module.js:470:12)
    at Function.Module._load (module.js:462:3)
```


Signed-off-by: Volker Theile <vtheile@suse.com>