### PR TITLE
mgr/dashboard_v2: Migrate cluster configuration

### DIFF
--- a/src/pybind/mgr/dashboard_v2/controllers/cluster_configuration.py
+++ b/src/pybind/mgr/dashboard_v2/controllers/cluster_configuration.py
@@ -1,0 +1,31 @@
+import cherrypy
+from ..tools import ApiController, RESTController, AuthRequired
+
+
+@ApiController('cluster_conf')
+@AuthRequired()
+class ClusterConfiguration(RESTController):
+    def list(self, service=None, level=None):
+        levels = ['basic', 'advanced', 'developer']
+        if level is not None:
+            assert level in levels
+
+        options = self.mgr.get("config_options")['options']
+
+        if service is not None:
+            options = [o for o in options if service in o['services']]
+
+        if level is not None:
+            options = [
+                o for o in options
+                if levels.index(o['level']) <= levels.index(level)
+            ]
+
+        return options
+
+    def get(self, name):
+        for option in self.mgr.get('config_options')['options']:
+            if option['name'] == name:
+                return option
+
+        raise cherrypy.HTTPError(404)

--- a/src/pybind/mgr/dashboard_v2/tests/test_cluster_configuration.py
+++ b/src/pybind/mgr/dashboard_v2/tests/test_cluster_configuration.py
@@ -1,0 +1,59 @@
+from __future__ import absolute_import
+
+from .helper import ControllerTestCase, authenticate
+
+
+class ClusterConfigurationTest(ControllerTestCase):
+    @authenticate
+    def test_list(self):
+        data = self._get('/api/cluster_conf')
+        self.assertStatus(200)
+        self.assertIsInstance(data, list)
+        self.assertGreater(len(data), 1000)
+
+        # service filter
+        data = self._get('/api/cluster_conf?service=mds')
+        self.assertTrue(all('mds' in e['services'] for e in data))
+        self.assertFalse(all('mon' in e['services'] for e in data))
+
+        # basic filter
+        data = self._get('/api/cluster_conf?level=basic')
+        self.assertTrue(all('basic' in e['level'] for e in data))
+
+        # advanced filter
+        data = self._get('/api/cluster_conf?level=advanced')
+        actual_levels = set([e['level'] for e in data])
+        self.assertTrue({'advanced', 'basic'}.issubset(actual_levels))
+
+        # developer filter
+        data = self._get('/api/cluster_conf?level=developer')
+        actual_levels = set([e['level'] for e in data])
+        self.assertTrue({'advanced', 'basic',
+                         'developer'}.issubset(actual_levels))
+
+        # two filters
+        data = self._get('/api/cluster_conf?level=advanced&service=mds')
+        actual_levels = set([e['level'] for e in data])
+        self.assertTrue({'advanced', 'basic'}.issubset(actual_levels))
+        self.assertTrue(all('mds' in e['services'] for e in data))
+
+    @authenticate
+    def test_get(self):
+        data = self._get('/api/cluster_conf/admin_socket')
+        self.assertStatus(200)
+        self.assertIn('name', data)
+        self.assertIn('daemon_default', data)
+        self.assertIn('long_desc', data)
+        self.assertIn('level', data)
+        self.assertIn('default', data)
+        self.assertIn('see_also', data)
+        self.assertIn('tags', data)
+        self.assertIn('min', data)
+        self.assertIn('max', data)
+        self.assertIn('services', data)
+        self.assertIn('enum_values', data)
+        self.assertIn('type', data)
+        self.assertIn('desc', data)
+
+        data = self._get('/api/cluster_conf/fantasy_name')
+        self.assertStatus(404)


### PR DESCRIPTION
This commit adds the ability to retrieve and filter the cluster
configuration of Ceph through the RESTful API.

Parameters `level` and `service` can be added to filter the list.

Example:

    http://<host>:<port>/api/cluster_conf?level=basic&service=mds

Signed-off-by: Patrick Nawracay <pnawracay@suse.com>