### PR TITLE
mgr/dashboard_v2: Add footer and header to hosts table

### DIFF
--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/cluster/hosts/hosts.component.html
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/cluster/hosts/hosts.component.html
@@ -7,9 +7,6 @@
 <cd-table [data]="hosts"
           [columns]="columns"
           columnMode="flex"
-          [toolHeader]="false"
-          [footer]="false"
-          [limit]="0"
           (fetchData)="getHosts()">
   <ng-template #servicesTpl let-value="value">
     <span *ngFor="let service of value; last as isLast">


### PR DESCRIPTION
This PR adds footer, pagination, filter, etc.. to the hosts table.

![screenshot from 2018-02-20 17-00-48](https://user-images.githubusercontent.com/14297426/36437703-a55e8724-165f-11e8-8d61-dfba8ae521ed.png)

Signed-off-by: Ricardo Marques <rimarques@suse.com>