### PR TITLE
mgr/dashboard_v2: Improve empty row style

### DIFF
--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/datatable/table/table.component.scss
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/datatable/table/table.component.scss
@@ -159,6 +159,14 @@
     }
   }
   .datatable-body {
+    .empty-row {
+      background-color: $warning-background-color;
+      text-align: center;
+      font-weight: bold;
+      font-style: italic;
+      padding-top: 5px;
+      padding-bottom: 5px;
+    }
     .datatable-body-row {
       &.clickable:hover .datatable-row-group {
         background-color: #eee;

--- a/src/pybind/mgr/dashboard_v2/frontend/src/defaults.scss
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/defaults.scss
@@ -1,3 +1,4 @@
+$warning-background-color: #fff3cd;
 $oa-color-blue: #288cea;
 $oa-color-light-blue: #afd9ee;
 $bg-color-light-blue: #d9edf7;


### PR DESCRIPTION
This PR will improve the style of an empty table.

**Before:**

![screenshot from 2018-02-21 10-52-55](https://user-images.githubusercontent.com/14297426/36476302-6967df5e-16f5-11e8-9c20-965379bcec95.png)

**After:**

![screenshot from 2018-02-21 10-44-31](https://user-images.githubusercontent.com/14297426/36476307-6fc51204-16f5-11e8-98f7-f6c2f2bff94a.png)

Signed-off-by: Ricardo Marques <rimarques@suse.com>