### PR TITLE
mgr/dashboard_v2: Fix datatable header layout in configuration doc

### DIFF
--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/datatable/table/table.component.scss
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/datatable/table/table.component.scss
@@ -58,6 +58,9 @@
   .oadatatableactions {
     display: inline-block;
   }
+  .form-group {
+    padding-left: 8px;
+  }
   .input-group {
     float: right;
     border-left: 1px solid rgba(0,0,0,.09);


### PR DESCRIPTION
Before:
![bildschirmfoto vom 2018-02-23 12-12-48](https://user-images.githubusercontent.com/1897962/36591640-f1ecdcf0-1892-11e8-86a1-72fc346a29c0.png)

After:
![bildschirmfoto vom 2018-02-23 12-12-21](https://user-images.githubusercontent.com/1897962/36591637-ed1fdb28-1892-11e8-9bb4-1b8fd0878455.png)

Signed-off-by: Volker Theile <vtheile@suse.com>