### PR TITLE
mgr/dashboard_v2: Add support for $PREFIX config

### DIFF
--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/cephfs/cephfs.service.ts
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/cephfs/cephfs.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 
 @Injectable()
 export class CephfsService {
-  baseURL = '/api/cephfs';
+  baseURL = 'api/cephfs';
 
   constructor(private http: HttpClient) {}
 

--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/cluster/monitor.service.ts
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/cluster/monitor.service.ts
@@ -6,6 +6,6 @@ export class MonitorService {
   constructor(private http: HttpClient) {}
 
   getMonitor() {
-    return this.http.get('/api/monitor');
+    return this.http.get('api/monitor');
   }
 }

--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/dashboard/dashboard.service.ts
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/dashboard/dashboard.service.ts
@@ -6,6 +6,6 @@ export class DashboardService {
   constructor(private http: HttpClient) {}
 
   getHealth() {
-    return this.http.get('/api/dashboard/health');
+    return this.http.get('api/dashboard/health');
   }
 }

--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/performance-counter/services/table-performance-counter.service.ts
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/performance-counter/services/table-performance-counter.service.ts
@@ -4,7 +4,7 @@ import { Injectable } from '@angular/core';
 @Injectable()
 export class TablePerformanceCounterService {
 
-  private url = '/api/perf_counters';
+  private url = 'api/perf_counters';
 
   constructor(private http: HttpClient) { }
 

--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/rgw/services/rgw-daemon.service.ts
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/rgw/services/rgw-daemon.service.ts
@@ -4,7 +4,7 @@ import { Injectable } from '@angular/core';
 @Injectable()
 export class RgwDaemonService {
 
-  private url = '/api/rgw/daemon';
+  private url = 'api/rgw/daemon';
 
   constructor(private http: HttpClient) { }
 

--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/services/auth.service.ts
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/services/auth.service.ts
@@ -12,13 +12,13 @@ export class AuthService {
   }
 
   login(credentials: Credentials) {
-    return this.http.post('/api/auth', credentials).toPromise().then((resp: Credentials) => {
+    return this.http.post('api/auth', credentials).toPromise().then((resp: Credentials) => {
       this.authStorageService.set(resp.username);
     });
   }
 
   logout() {
-    return this.http.delete('/api/auth').toPromise().then(() => {
+    return this.http.delete('api/auth').toPromise().then(() => {
       this.authStorageService.remove();
     });
   }

--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/services/configuration.service.ts
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/services/configuration.service.ts
@@ -6,6 +6,6 @@ export class ConfigurationService {
   constructor(private http: HttpClient) {}
 
   getConfigData() {
-    return this.http.get('/api/cluster_conf/');
+    return this.http.get('api/cluster_conf/');
   }
 }

--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/services/host.service.ts
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/services/host.service.ts
@@ -8,7 +8,7 @@ export class HostService {
   }
 
   list() {
-    return this.http.get('/api/host').toPromise().then((resp: any) => {
+    return this.http.get('api/host').toPromise().then((resp: any) => {
       return resp;
     });
   }

--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/services/pool.service.ts
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/services/pool.service.ts
@@ -8,7 +8,7 @@ export class PoolService {
   }
 
   rbdPoolImages(pool) {
-    return this.http.get(`/api/rbd/${pool}`).toPromise().then((resp: any) => {
+    return this.http.get(`api/rbd/${pool}`).toPromise().then((resp: any) => {
       return resp;
     });
   }

--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/services/rbd-mirroring.service.ts
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/services/rbd-mirroring.service.ts
@@ -6,6 +6,6 @@ export class RbdMirroringService {
   constructor(private http: HttpClient) {}
 
   get() {
-    return this.http.get('/api/rbdmirror');
+    return this.http.get('api/rbdmirror');
   }
 }

--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/services/summary.service.ts
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/services/summary.service.ts
@@ -19,7 +19,7 @@ export class SummaryService {
 
   refresh() {
     if (this.authStorageService.isLoggedIn()) {
-      this.http.get('/api/summary').subscribe(data => {
+      this.http.get('api/summary').subscribe(data => {
         this.summaryDataSource.next(data);
       });
     }

--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/services/tcmu-iscsi.service.ts
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/services/tcmu-iscsi.service.ts
@@ -8,7 +8,7 @@ export class TcmuIscsiService {
   }
 
   tcmuiscsi() {
-    return this.http.get('/api/tcmuiscsi').toPromise().then((resp: any) => {
+    return this.http.get('api/tcmuiscsi').toPromise().then((resp: any) => {
       return resp;
     });
   }

--- a/src/pybind/mgr/dashboard_v2/frontend/src/index.html
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/index.html
@@ -3,7 +3,10 @@
 <head>
   <meta charset="utf-8">
   <title>Ceph</title>
-  <base href="/">
+
+  <script>
+    document.write('<base href="' + document.location+ '" />');
+  </script>
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">

--- a/src/pybind/mgr/dashboard_v2/module.py
+++ b/src/pybind/mgr/dashboard_v2/module.py
@@ -38,6 +38,14 @@ def os_exit_noop(*args):
 os._exit = os_exit_noop
 
 
+def prepare_url_prefix(url_prefix):
+    """
+    return '' if no prefix, or '/prefix' without slash in the end.
+    """
+    url_prefix = urljoin('/', url_prefix)
+    return url_prefix.rstrip('/')
+
+
 class Module(MgrModule):
     """
     dashboard module entrypoint
@@ -83,13 +91,6 @@ class Module(MgrModule):
         self.log.info('server_addr: %s server_port: %s', server_addr,
                       server_port)
 
-        def prepare_url_prefix(url_prefix):
-            """
-            return '' if no prefix, or '/prefix' without slash in the end.
-            """
-            url_prefix = urljoin('/', url_prefix)
-            return url_prefix.rstrip('/')
-
         self._url_prefix = prepare_url_prefix(self.get_config('url_prefix',
                                                               default=''))
 
@@ -124,8 +125,8 @@ class Module(MgrModule):
             self.url_prefix
         ))
 
-        cherrypy.tree.mount(Module.ApiRoot(self), '/api')
-        cherrypy.tree.mount(Module.StaticRoot(), '/', config=config)
+        cherrypy.tree.mount(Module.ApiRoot(self), '{}/api'.format(self.url_prefix))
+        cherrypy.tree.mount(Module.StaticRoot(), '{}/'.format(self.url_prefix), config=config)
 
     def serve(self):
         if 'COVERAGE_ENABLED' in os.environ:
@@ -259,7 +260,9 @@ class StandbyModule(MgrStandbyModule):
                     """
                     return template.format(delay=5)
 
-        cherrypy.tree.mount(Root(), "/", {})
+        url_prefix = prepare_url_prefix(self.get_config('url_prefix',
+                                                        default=''))
+        cherrypy.tree.mount(Root(), "{}/".format(url_prefix), {})
         self.log.info("Starting engine...")
         cherrypy.engine.start()
         self.log.info("Waiting for engine...")


### PR DESCRIPTION
This PR will add support for URL prefix config:

    ceph config-key set mgr/dashboard_v2/url_prefix $PREFIX

as documented [here](http://docs.ceph.com/docs/master/mgr/dashboard/).

Signed-off-by: Ricardo Marques <rimarques@suse.com>