### PR TITLE
mgr/dashboard_v2: Enable table header and footer on perfcounters

### DIFF
--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.html
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.html
@@ -1,9 +1,6 @@
 <cd-table [data]="counters"
           [columns]="columns"
           columnMode="flex"
-          [toolHeader]="false"
-          [footer]="false"
-          [limit]="0"
           (fetchData)="getCounters()">
   <ng-template #valueTpl let-row="row">
     {{ row.value | dimless }} {{ row.unit }}


### PR DESCRIPTION
Enable the ability to filter and paginate the performance counter tables to make it easier to find specific information quickly.

Signed-off-by: Lenz Grimmer <lgrimmer@suse.com>